### PR TITLE
nonce: use slice instead of array

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -116,14 +116,14 @@ func TestDialerRequest(t *testing.T) {
 	}
 }
 
-func makeAccept(nonce [nonceSize]byte) []byte {
+func makeAccept(nonce []byte) []byte {
 	accept := make([]byte, acceptSize)
-	putAccept(nonce, accept)
+	initAcceptFromNonce(accept, nonce)
 	return accept
 }
 
 func BenchmarkPutAccept(b *testing.B) {
-	var nonce [nonceSize]byte
+	nonce := make([]byte, nonceSize)
 	_, err := rand.Read(nonce[:])
 	if err != nil {
 		b.Fatal(err)
@@ -131,12 +131,12 @@ func BenchmarkPutAccept(b *testing.B) {
 	p := make([]byte, acceptSize)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		putAccept(nonce, p)
+		initAcceptFromNonce(p, nonce)
 	}
 }
 
 func BenchmarkCheckNonce(b *testing.B) {
-	var nonce [nonceSize]byte
+	nonce := make([]byte, nonceSize)
 	_, err := rand.Read(nonce[:])
 	if err != nil {
 		b.Fatal(err)
@@ -146,7 +146,7 @@ func BenchmarkCheckNonce(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = checkNonce(accept, nonce)
+		_ = checkAcceptFromNonce(nonce, accept)
 	}
 }
 
@@ -498,11 +498,11 @@ func TestDialerHandshake(t *testing.T) {
 					k := make([]byte, nonceSize)
 					rand.Read(k)
 					nonce := string(k)
-					accept := makeAccept(strToNonce(nonce))
+					accept := makeAccept(strToBytes(nonce))
 					test.res.Header.Set(headerSecAccept, string(accept))
 				case acceptValid:
 					nonce := req.Header.Get(headerSecKey)
-					accept := makeAccept(strToNonce(nonce))
+					accept := makeAccept(strToBytes(nonce))
 					test.res.Header.Set(headerSecAccept, string(accept))
 				}
 
@@ -702,9 +702,9 @@ func BenchmarkDialer(b *testing.B) {
 		}
 		rs := make([][]byte, b.N)
 		for i := range rs {
-			var nonce [nonceSize]byte
+			nonce := make([]byte, nonceSize)
 			base64.StdEncoding.Encode(
-				nonce[:],
+				nonce,
 				nonceBytes[i*nonceKeySize:i*nonceKeySize+nonceKeySize],
 			)
 			accept := makeAccept(nonce)

--- a/http.go
+++ b/http.go
@@ -281,7 +281,7 @@ func httpWriteUpgradeRequest(
 	bw.WriteString(crlf)
 }
 
-func httpWriteResponseUpgrade(bw *bufio.Writer, nonce [nonceSize]byte, hs Handshake, hw func(io.Writer)) {
+func httpWriteResponseUpgrade(bw *bufio.Writer, nonce []byte, hs Handshake, hw func(io.Writer)) {
 	bw.WriteString(textUpgrade)
 
 	httpWriteHeaderKey(bw, headerSecAccept)

--- a/http_test.go
+++ b/http_test.go
@@ -61,7 +61,7 @@ func BenchmarkHttpWriteUpgradeRequest(b *testing.B) {
 	} {
 		bw := bufio.NewWriter(ioutil.Discard)
 		nonce := make([]byte, nonceSize)
-		putNewNonce(nonce)
+		initNonce(nonce)
 		b.ResetTimer()
 		b.Run("", func(b *testing.B) {
 			for i := 0; i < b.N; i++ {

--- a/server.go
+++ b/server.go
@@ -163,7 +163,7 @@ func (u HTTPUpgrader) Upgrade(r *http.Request, w http.ResponseWriter, h http.Hea
 		hw = HeaderWriter(h)
 	}
 
-	httpWriteResponseUpgrade(rw.Writer, strToNonce(nonce), hs, hw)
+	httpWriteResponseUpgrade(rw.Writer, strToBytes(nonce), hs, hw)
 	err = rw.Writer.Flush()
 
 	return
@@ -383,7 +383,7 @@ func (u Upgrader) Upgrade(conn io.ReadWriter) (hs Handshake, err error) {
 		// headerSeen reports which header was seen by setting corresponding
 		// bit on.
 		headerSeen byte
-		nonce      [nonceSize]byte
+		nonce      nonce
 		hcb        func(io.Writer)
 		hw         headerWriter
 	)
@@ -540,7 +540,7 @@ func (u Upgrader) Upgrade(conn io.ReadWriter) (hs Handshake, err error) {
 		return
 	}
 
-	httpWriteResponseUpgrade(bw, nonce, hs, hw.flush)
+	httpWriteResponseUpgrade(bw, nonce.bytes(), hs, hw.flush)
 	err = bw.Flush()
 
 	return

--- a/server_test.go
+++ b/server_test.go
@@ -29,7 +29,7 @@ type upgradeCase struct {
 	onHeader  func(k, v []byte) (error, int)
 	onRequest func(h, u []byte) (error, int)
 
-	nonce        [nonceSize]byte
+	nonce        []byte
 	removeSecKey bool
 	badSecKey    bool
 
@@ -295,7 +295,7 @@ func TestHTTPUpgrader(t *testing.T) {
 	for _, test := range upgradeCases {
 		t.Run(test.label, func(t *testing.T) {
 			if !test.removeSecKey {
-				nonce := test.nonce[:]
+				nonce := test.nonce
 				if test.badSecKey {
 					nonce = nonce[:nonceSize-1]
 				}
@@ -759,8 +759,9 @@ func mustMakeErrResponse(code int, err error, headers http.Header) *http.Respons
 	return res
 }
 
-func mustMakeNonce() (ret [nonceSize]byte) {
-	putNewNonce(ret[:])
+func mustMakeNonce() (ret []byte) {
+	ret = make([]byte, nonceSize)
+	initNonce(ret)
 	return
 }
 

--- a/util.go
+++ b/util.go
@@ -54,18 +54,6 @@ func btsToString(bts []byte) string {
 	return *(*string)(unsafe.Pointer(s))
 }
 
-func strToNonce(str string) [nonceSize]byte {
-	s := *(*reflect.StringHeader)(unsafe.Pointer(&str))
-	n := *(*[nonceSize]byte)(unsafe.Pointer(s.Data))
-	return n
-}
-
-func btsToNonce(bts []byte) [nonceSize]byte {
-	b := *(*reflect.SliceHeader)(unsafe.Pointer(&bts))
-	n := *(*[nonceSize]byte)(unsafe.Pointer(b.Data))
-	return n
-}
-
 // asciiToInt converts bytes to int.
 func asciiToInt(bts []byte) (ret int, err error) {
 	// ASCII numbers all start with the high-order bits 0011.


### PR DESCRIPTION
This commit also brings type `nonce` that helps to stick nonce bytes
array to the stack. Usually its `nonce.bytes()` method used to get slice
backed by array from stack.