### PR TITLE
Fix some lint warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,10 @@ os:
   - osx
 
 go:
-  - 1.7
-  - 1.8
-  - 1.9
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.x
 
 install:
   - go get github.com/gobwas/pool

--- a/dialer.go
+++ b/dialer.go
@@ -109,7 +109,7 @@ type Dialer struct {
 	// If it is not nil, then it is used instead of net.Dialer.
 	NetDial func(ctx context.Context, network, addr string) (net.Conn, error)
 
-	// TLSClient is the callback that will be called after succesful dial with
+	// TLSClient is the callback that will be called after successful dial with
 	// received connection and its remote host name. If it is nil, then the
 	// default tls.Client() will be used.
 	// If it is not nil, then TLSConfig field is ignored.
@@ -177,7 +177,7 @@ func (d Dialer) Dial(ctx context.Context, urlstr string) (conn net.Conn, br *buf
 	} else {
 		// Context could be canceled or its deadline could be exceeded.
 		// Start the interrupter goroutine to handle context cancelation.
-		done := setupContextDeadliner(conn, ctx)
+		done := setupContextDeadliner(ctx, conn)
 		defer func() {
 			// Map Upgrade() error to a possible context expiration error. That
 			// is, even if Upgrade() err is nil, context could be already
@@ -526,7 +526,7 @@ func matchSelectedExtensions(selected []byte, wanted, received []httphead.Option
 // connection "poisoned" by SetDeadline() call. In that case done(&err) will
 // store at *err ctx.Err() result. If err is caused not by timeout, it will
 // leaved untouched.
-func setupContextDeadliner(conn net.Conn, ctx context.Context) (done func(*error)) {
+func setupContextDeadliner(ctx context.Context, conn net.Conn) (done func(*error)) {
 	var (
 		quit      = make(chan struct{})
 		interrupt = make(chan error, 1)

--- a/dialer.go
+++ b/dialer.go
@@ -177,7 +177,7 @@ func (d Dialer) Dial(ctx context.Context, urlstr string) (conn net.Conn, br *buf
 	} else {
 		// Context could be canceled or its deadline could be exceeded.
 		// Start the interrupter goroutine to handle context cancelation.
-		done := setupContextDeadliner(ctx, conn)
+		done := setupContextDeadliner(conn, ctx)
 		defer func() {
 			// Map Upgrade() error to a possible context expiration error. That
 			// is, even if Upgrade() err is nil, context could be already
@@ -526,7 +526,7 @@ func matchSelectedExtensions(selected []byte, wanted, received []httphead.Option
 // connection "poisoned" by SetDeadline() call. In that case done(&err) will
 // store at *err ctx.Err() result. If err is caused not by timeout, it will
 // leaved untouched.
-func setupContextDeadliner(ctx context.Context, conn net.Conn) (done func(*error)) {
+func setupContextDeadliner(conn net.Conn, ctx context.Context) (done func(*error)) {
 	var (
 		quit      = make(chan struct{})
 		interrupt = make(chan error, 1)

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -635,7 +635,7 @@ func TestDialerCancelation(t *testing.T) {
 					if t.IsZero() {
 						return nil
 					}
-					d := time.Until(t)
+					d := t.Sub(time.Now())
 					if d < 0 {
 						deadline <- ioErrDeadline
 					} else {

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -635,7 +635,7 @@ func TestDialerCancelation(t *testing.T) {
 					if t.IsZero() {
 						return nil
 					}
-					d := t.Sub(time.Now())
+					d := time.Until(t)
 					if d < 0 {
 						deadline <- ioErrDeadline
 					} else {
@@ -692,8 +692,7 @@ func TestDialerCancelation(t *testing.T) {
 
 func BenchmarkDialer(b *testing.B) {
 	for _, test := range []struct {
-		dialer   Dialer
-		response *http.Response
+		dialer Dialer
 	}{
 		{
 			dialer: DefaultDialer,
@@ -868,31 +867,3 @@ func (s stubConn) SetWriteDeadline(t time.Time) error {
 	}
 	return nil
 }
-
-func makeNonceFrom(bts []byte) (ret [nonceSize]byte) {
-	base64.StdEncoding.Encode(ret[:], bts)
-	return
-}
-
-func nonceAsSlice(bts [nonceSize]byte) []byte {
-	return bts[:]
-}
-
-type stubPool struct {
-	getCalls int
-	putCalls int
-}
-
-type stubWritePool struct {
-	stubPool
-}
-
-func (s *stubWritePool) Get(w io.Writer) *bufio.Writer { s.getCalls++; return bufio.NewWriter(w) }
-func (s *stubWritePool) Put(bw *bufio.Writer)          { s.putCalls++ }
-
-type stubReadPool struct {
-	stubPool
-}
-
-func (s *stubReadPool) Get(r io.Reader) *bufio.Reader { s.getCalls++; return bufio.NewReader(r) }
-func (s *stubReadPool) Put(br *bufio.Reader)          { s.putCalls++ }

--- a/server_test.go
+++ b/server_test.go
@@ -774,8 +774,3 @@ func mustMakeNonce() (ret []byte) {
 	initNonce(ret)
 	return
 }
-
-func mustMakeNonceStr() string {
-	n := mustMakeNonce()
-	return string(n[:])
-}

--- a/wsutil/helper.go
+++ b/wsutil/helper.go
@@ -63,12 +63,18 @@ func ReadServerMessage(r io.Reader, m []Message) ([]Message, error) {
 // It takes care on handling all control frames. It will write response on
 // control frames to the write part of rw. It blocks until some data frame
 // will be received.
+//
+// Note this may handle and write control frames into the writer part of a given
+//  io.ReadWriter.
 func ReadData(rw io.ReadWriter, s ws.State) ([]byte, ws.OpCode, error) {
 	return readData(rw, s, ws.OpText|ws.OpBinary)
 }
 
 // ReadClientData reads next data message from rw, considering that caller
 // represents server side. It is a shortcut for ReadData(rw, ws.StateServerSide).
+//
+// Note this may handle and write control frames into the writer part of a given
+//  io.ReadWriter.
 func ReadClientData(rw io.ReadWriter) ([]byte, ws.OpCode, error) {
 	return ReadData(rw, ws.StateServerSide)
 }
@@ -76,6 +82,9 @@ func ReadClientData(rw io.ReadWriter) ([]byte, ws.OpCode, error) {
 // ReadClientText reads next text message from rw, considering that caller
 // represents server side. It is a shortcut for ReadData(rw, ws.StateServerSide).
 // It discards received binary messages.
+//
+// Note this may handle and write control frames into the writer part of a given
+//  io.ReadWriter.
 func ReadClientText(rw io.ReadWriter) ([]byte, error) {
 	p, _, err := readData(rw, ws.StateServerSide, ws.OpText)
 	return p, err
@@ -84,6 +93,9 @@ func ReadClientText(rw io.ReadWriter) ([]byte, error) {
 // ReadClientBinary reads next binary message from rw, considering that caller
 // represents server side. It is a shortcut for ReadData(rw, ws.StateServerSide).
 // It discards received text messages.
+//
+// Note this may handle and write control frames into the writer part of a given
+//  io.ReadWriter.
 func ReadClientBinary(rw io.ReadWriter) ([]byte, error) {
 	p, _, err := readData(rw, ws.StateServerSide, ws.OpBinary)
 	return p, err
@@ -91,6 +103,9 @@ func ReadClientBinary(rw io.ReadWriter) ([]byte, error) {
 
 // ReadServerData reads next data message from rw, considering that caller
 // represents client side. It is a shortcut for ReadData(rw, ws.StateClientSide).
+//
+// Note this may handle and write control frames into the writer part of a given
+//  io.ReadWriter.
 func ReadServerData(rw io.ReadWriter) ([]byte, ws.OpCode, error) {
 	return ReadData(rw, ws.StateClientSide)
 }
@@ -98,6 +113,9 @@ func ReadServerData(rw io.ReadWriter) ([]byte, ws.OpCode, error) {
 // ReadServerText reads next text message from rw, considering that caller
 // represents client side. It is a shortcut for ReadData(rw, ws.StateClientSide).
 // It discards received binary messages.
+//
+// Note this may handle and write control frames into the writer part of a given
+//  io.ReadWriter.
 func ReadServerText(rw io.ReadWriter) ([]byte, error) {
 	p, _, err := readData(rw, ws.StateClientSide, ws.OpText)
 	return p, err
@@ -106,6 +124,9 @@ func ReadServerText(rw io.ReadWriter) ([]byte, error) {
 // ReadServerBinary reads next binary message from rw, considering that caller
 // represents client side. It is a shortcut for ReadData(rw, ws.StateClientSide).
 // It discards received text messages.
+//
+// Note this may handle and write control frames into the writer part of a given
+//  io.ReadWriter.
 func ReadServerBinary(rw io.ReadWriter) ([]byte, error) {
 	p, _, err := readData(rw, ws.StateClientSide, ws.OpBinary)
 	return p, err
@@ -171,6 +192,9 @@ func HandleClientControl(conn io.Writer, op ws.OpCode, p []byte) error {
 // HandleServerControl handles control frame from conn and writes
 // response when needed. It considers that caller represents client
 // side.
+//
+// Note this may handle and write control frames into the writer part of a given
+//  io.ReadWriter.
 func HandleServerControl(conn io.ReadWriter, op ws.OpCode, p []byte) error {
 	return ControlHandler(conn, ws.StateClientSide)(ws.Header{
 		Length: int64(len(p)),

--- a/wsutil/helper.go
+++ b/wsutil/helper.go
@@ -195,7 +195,7 @@ func HandleClientControl(conn io.Writer, op ws.OpCode, p []byte) error {
 //
 // Note this may handle and write control frames into the writer part of a given
 //  io.ReadWriter.
-func HandleServerControl(conn io.ReadWriter, op ws.OpCode, p []byte) error {
+func HandleServerControl(conn io.Writer, op ws.OpCode, p []byte) error {
 	return ControlHandler(conn, ws.StateClientSide)(ws.Header{
 		Length: int64(len(p)),
 		OpCode: op,


### PR DESCRIPTION
Have fixed few warnings. I haven't touched this one:
```
frame.go:181:13:warning: struct of size 24 could be 16 (maligned)
```
I'm not sure how it's safe to change order of fields for `Header`(this might also impact `Frame`)