### PR TITLE
README: Add JSON-specific req/resp example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,36 @@ func main() {
 }
 ```
 
+We can apply the same pattern to read and write structured responses through a JSON encoder and decoder.:
+
+```go
+	...
+	var (
+		r = wsutil.NewReader(conn, ws.StateServerSide)
+		w = wsutil.NewWriter(conn, ws.StateServerSide, ws.OpText)
+		decoder = json.NewDecoder(r)
+		encoder = json.NewEncoder(w)
+	)
+	for {
+		if _, err = r.NextFrame(); err != nil {
+			return err
+		}
+		var req Request
+		if err := decoder.Decode(&req); err != nil {
+			return err
+		}
+		var resp Response
+		if err := encoder.Encode(&resp); err != nil {
+			return err
+		}
+		if err = w.Flush(); err != nil {
+			return err
+		}
+	}
+	...
+}
+```
+
 The lower-level example without `wsutil`:
 
 ```go

--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ We can apply the same pattern to read and write structured responses through a J
 		}
 	}
 	...
-}
 ```
 
 The lower-level example without `wsutil`:


### PR DESCRIPTION
(As discussed in #46)

Do we also need to call `writer.Reset(conn, state, header.OpCode)` between writes like the example above?

It's really hard to tell what the required sequence of flow control operations is for different levels of abstraction in the API.