### PR TITLE
fix: panic caused by uintptr

### DIFF
--- a/cipher.go
+++ b/cipher.go
@@ -42,13 +42,13 @@ func Cipher(payload []byte, mask [4]byte, offset int) {
 
 	// Get pointer to payload at ln index to
 	// skip manual processed bytes above.
-	p := uintptr(unsafe.Pointer(&payload[ln]))
+	p := unsafe.Pointer(&payload[ln])
 	// Also skip right part as the division by 8 remainder.
 	// Divide it by 8 to get number of uint64 parts remaining to process.
 	n = (n - rn) >> 3
 	// Process the rest of bytes as uint64.
-	for i := 0; i < n; i, p = i+1, p+8 {
-		v := (*uint64)(unsafe.Pointer(p))
+	for i := 0; i < n; i++ {
+		v := (*uint64)(unsafe.Pointer(uintptr(p) + uintptr(i)*8))
 		*v = *v ^ m2
 	}
 }

--- a/nonce.go
+++ b/nonce.go
@@ -8,9 +8,7 @@ import (
 	"hash"
 	"io"
 	"math/rand"
-	"reflect"
 	"sync"
-	"unsafe"
 )
 
 const (
@@ -38,9 +36,7 @@ var sha1Pool sync.Pool
 type nonce [nonceSize]byte
 
 func (n *nonce) bytes() []byte {
-	h := uintptr(unsafe.Pointer(n))
-	b := &reflect.SliceHeader{Data: h, Len: nonceSize, Cap: nonceSize}
-	return *(*[]byte)(unsafe.Pointer(b))
+	return n[:]
 }
 
 func acquireSha1() hash.Hash {
@@ -94,12 +90,7 @@ func initAcceptFromNonce(dst, nonce []byte) {
 	sha.Write(webSocketMagic)
 
 	var sb [sha1.Size]byte
-	sh := uintptr(unsafe.Pointer(&sb))
-	sum := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: sh,
-		Len:  0,
-		Cap:  sha1.Size,
-	}))
+	sum := sb[:0]
 	sum = sha.Sum(sum)
 
 	base64.StdEncoding.Encode(dst, sum)
@@ -107,12 +98,7 @@ func initAcceptFromNonce(dst, nonce []byte) {
 
 func writeAccept(w io.Writer, nonce []byte) (int, error) {
 	var b [acceptSize]byte
-	bp := uintptr(unsafe.Pointer(&b))
-	bts := *(*[]byte)(unsafe.Pointer(&reflect.SliceHeader{
-		Data: bp,
-		Len:  acceptSize,
-		Cap:  acceptSize,
-	}))
+	bts := b[:]
 
 	initAcceptFromNonce(bts, nonce)
 

--- a/read.go
+++ b/read.go
@@ -4,8 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"reflect"
-	"unsafe"
 )
 
 // Errors used by frame reader.
@@ -28,9 +26,7 @@ func ReadHeader(r io.Reader) (h Header, err error) {
 	// says that "Implementations must not retain p".
 	// See https://golang.org/pkg/io/#Reader
 	var b [MaxHeaderSize - 2]byte
-	bp := uintptr(unsafe.Pointer(&b))
-	bh := &reflect.SliceHeader{Data: bp, Len: 2, Cap: MaxHeaderSize - 2}
-	bts := *(*[]byte)(unsafe.Pointer(bh))
+	bts := b[0:2 : MaxHeaderSize-2]
 
 	// Prepare to hold first 2 bytes to choose size of next read.
 	_, err = io.ReadFull(r, bts)

--- a/util.go
+++ b/util.go
@@ -221,13 +221,10 @@ func strEqualFold(s, p string) bool {
 	}
 
 	ah := *(*reflect.StringHeader)(unsafe.Pointer(&s))
-	ap := ah.Data + uintptr(m)
 	bh := *(*reflect.StringHeader)(unsafe.Pointer(&p))
-	bp := bh.Data + uintptr(m)
-
-	for i := 0; i < n; i, ap, bp = i+1, ap+8, bp+8 {
-		av := *(*uint64)(unsafe.Pointer(ap))
-		bv := *(*uint64)(unsafe.Pointer(bp))
+	for i := 0; i < n; i++ {
+		av := *(*uint64)(unsafe.Pointer(ah.Data + uintptr(m+i*8)))
+		bv := *(*uint64)(unsafe.Pointer(bh.Data + uintptr(m+i*8)))
 		if av|toLower8 != bv|toLower8 {
 			return false
 		}
@@ -259,13 +256,10 @@ func btsEqualFold(s, p []byte) bool {
 	}
 
 	ah := *(*reflect.SliceHeader)(unsafe.Pointer(&s))
-	ap := ah.Data + uintptr(m)
 	bh := *(*reflect.SliceHeader)(unsafe.Pointer(&p))
-	bp := bh.Data + uintptr(m)
-
-	for i := 0; i < n; i, ap, bp = i+1, ap+8, bp+8 {
-		av := *(*uint64)(unsafe.Pointer(ap))
-		bv := *(*uint64)(unsafe.Pointer(bp))
+	for i := 0; i < n; i++ {
+		av := *(*uint64)(unsafe.Pointer(ah.Data + uintptr(m+i*8)))
+		bv := *(*uint64)(unsafe.Pointer(bh.Data + uintptr(m+i*8)))
 		if av|toLower8 != bv|toLower8 {
 			return false
 		}

--- a/write.go
+++ b/write.go
@@ -3,8 +3,6 @@ package ws
 import (
 	"encoding/binary"
 	"io"
-	"reflect"
-	"unsafe"
 )
 
 // Header size length bounds in bytes.
@@ -57,14 +55,7 @@ func WriteHeader(w io.Writer, h Header) error {
 	// says that "Implementations must not retain p".
 	// See https://golang.org/pkg/io/#Writer
 	var b [MaxHeaderSize]byte
-	bp := uintptr(unsafe.Pointer(&b))
-	bh := &reflect.SliceHeader{
-		Data: bp,
-		Len:  MaxHeaderSize,
-		Cap:  MaxHeaderSize,
-	}
-	bts := *(*[]byte)(unsafe.Pointer(bh))
-	_ = bts[MaxHeaderSize-1] // bounds check hint to compiler.
+	bts := b[:]
 
 	if h.Fin {
 		bts[0] |= bit0


### PR DESCRIPTION
When I used this library on windows, ReadHeader returns full zero Header after about 3-5 calls, and sometimes the program panic. After some debug I found it's caused by the usage of uintptr.

According to doc of `unsafe.Pointer`, most of the previous uintptr usage are incorrect. This PR fixes the issue.

Change-Id: Iddd9c07d7c1c1d3f1cf5239b6524e9399b49725d