### PR TITLE
add ws.OpClose check in codec example on the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,12 @@ We can apply the same pattern to read and write structured responses through a J
 		encoder = json.NewEncoder(w)
 	)
 	for {
-		if _, err = r.NextFrame(); err != nil {
+		hdr, err = r.NextFrame()
+		if err != nil {
 			return err
+		}
+		if hdr.OpCode == ws.OpClose {
+			return io.EOF
 		}
 		var req Request
 		if err := decoder.Decode(&req); err != nil {


### PR DESCRIPTION
Took me a bit of time to figure out why I was seeing `invalid character '\x03' looking for beginning of value` every time I refreshed the page (closing the connection on the client)

This completes the example a bit better. Thanks again for the great library!