### PR TITLE
Send headers with Sec-WebSocket-* capitalization

### DIFF
--- a/dialer.go
+++ b/dialer.go
@@ -371,14 +371,14 @@ func (d Dialer) Upgrade(conn io.ReadWriter, u *url.URL) (br *bufio.Reader, hs Ha
 		}
 
 		switch btsToString(k) {
-		case headerUpgrade:
+		case headerUpgradeCanonical:
 			headerSeen |= headerSeenUpgrade
 			if !bytes.Equal(v, specHeaderValueUpgrade) && !btsEqualFold(v, specHeaderValueUpgrade) {
 				err = ErrHandshakeBadUpgrade
 				return
 			}
 
-		case headerConnection:
+		case headerConnectionCanonical:
 			headerSeen |= headerSeenConnection
 			// Note that as RFC6455 says:
 			//   > A |Connection| header field with value "Upgrade".

--- a/dialer.go
+++ b/dialer.go
@@ -389,14 +389,14 @@ func (d Dialer) Upgrade(conn io.ReadWriter, u *url.URL) (br *bufio.Reader, hs Ha
 				return
 			}
 
-		case headerSecAccept:
+		case headerSecAcceptCanonical:
 			headerSeen |= headerSeenSecAccept
 			if !checkAcceptFromNonce(v, nonce) {
 				err = ErrHandshakeBadSecAccept
 				return
 			}
 
-		case headerSecProtocol:
+		case headerSecProtocolCanonical:
 			// RFC6455 1.3:
 			//   "The server selects one or none of the acceptable protocols
 			//   and echoes that value in its handshake to indicate that it has
@@ -414,7 +414,7 @@ func (d Dialer) Upgrade(conn io.ReadWriter, u *url.URL) (br *bufio.Reader, hs Ha
 				return
 			}
 
-		case headerSecExtensions:
+		case headerSecExtensionsCanonical:
 			hs.Extensions, err = matchSelectedExtensions(v, d.Extensions, hs.Extensions)
 			if err != nil {
 				return

--- a/example/autobahn/autobahn.go
+++ b/example/autobahn/autobahn.go
@@ -33,7 +33,7 @@ func main() {
 
 	ln, err := net.Listen("tcp", *addr)
 	if err != nil {
-		log.Fatalf("listen %q error: %v", err)
+		log.Fatalf("listen %q error: %v", *addr, err)
 	}
 	log.Printf("listening %s (%q)", ln.Addr(), *addr)
 

--- a/http.go
+++ b/http.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"strconv"
 
@@ -48,11 +49,11 @@ var (
 	headerSecKey        = "Sec-WebSocket-Key"
 	headerSecAccept     = "Sec-WebSocket-Accept"
 
-	headerSecVersionCanonical    = "Sec-Websocket-Version"
-	headerSecProtocolCanonical   = "Sec-Websocket-Protocol"
-	headerSecExtensionsCanonical = "Sec-Websocket-Extensions"
-	headerSecKeyCanonical        = "Sec-Websocket-Key"
-	headerSecAcceptCanonical     = "Sec-Websocket-Accept"
+	headerSecVersionCanonical    = textproto.CanonicalMIMEHeaderKey(headerSecVersion)
+	headerSecProtocolCanonical   = textproto.CanonicalMIMEHeaderKey(headerSecProtocol)
+	headerSecExtensionsCanonical = textproto.CanonicalMIMEHeaderKey(headerSecExtensions)
+	headerSecKeyCanonical        = textproto.CanonicalMIMEHeaderKey(headerSecKey)
+	headerSecAcceptCanonical     = textproto.CanonicalMIMEHeaderKey(headerSecAccept)
 )
 
 var (

--- a/http.go
+++ b/http.go
@@ -48,9 +48,9 @@ var (
 	headerSecKey        = "Sec-WebSocket-Key"
 	headerSecAccept     = "Sec-WebSocket-Accept"
 
-	headerHostCanonical          = textproto.CanonicalMIMEHeaderKey("Host")
-	headerUpgradeCanonical       = textproto.CanonicalMIMEHeaderKey("Upgrade")
-	headerConnectionCanonical    = textproto.CanonicalMIMEHeaderKey("Connection")
+	headerHostCanonical          = textproto.CanonicalMIMEHeaderKey(headerHost)
+	headerUpgradeCanonical       = textproto.CanonicalMIMEHeaderKey(headerUpgrade)
+	headerConnectionCanonical    = textproto.CanonicalMIMEHeaderKey(headerConnection)
 	headerSecVersionCanonical    = textproto.CanonicalMIMEHeaderKey(headerSecVersion)
 	headerSecProtocolCanonical   = textproto.CanonicalMIMEHeaderKey(headerSecProtocol)
 	headerSecExtensionsCanonical = textproto.CanonicalMIMEHeaderKey(headerSecExtensions)

--- a/http.go
+++ b/http.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"io"
 	"net/http"
-	"net/textproto"
 	"net/url"
 	"strconv"
 
@@ -39,14 +38,21 @@ var (
 )
 
 var (
-	headerHost          = textproto.CanonicalMIMEHeaderKey("Host")
-	headerUpgrade       = textproto.CanonicalMIMEHeaderKey("Upgrade")
-	headerConnection    = textproto.CanonicalMIMEHeaderKey("Connection")
-	headerSecVersion    = textproto.CanonicalMIMEHeaderKey("Sec-Websocket-Version")
-	headerSecProtocol   = textproto.CanonicalMIMEHeaderKey("Sec-Websocket-Protocol")
-	headerSecExtensions = textproto.CanonicalMIMEHeaderKey("Sec-Websocket-Extensions")
-	headerSecKey        = textproto.CanonicalMIMEHeaderKey("Sec-Websocket-Key")
-	headerSecAccept     = textproto.CanonicalMIMEHeaderKey("Sec-Websocket-Accept")
+	headerHost       = "Host"
+	headerUpgrade    = "Upgrade"
+	headerConnection = "Connection"
+
+	headerSecVersion    = "Sec-WebSocket-Version"
+	headerSecProtocol   = "Sec-WebSocket-Protocol"
+	headerSecExtensions = "Sec-WebSocket-Extensions"
+	headerSecKey        = "Sec-WebSocket-Key"
+	headerSecAccept     = "Sec-WebSocket-Accept"
+
+	headerSecVersionCanonical    = "Sec-Websocket-Version"
+	headerSecProtocolCanonical   = "Sec-Websocket-Protocol"
+	headerSecExtensionsCanonical = "Sec-Websocket-Extensions"
+	headerSecKeyCanonical        = "Sec-Websocket-Key"
+	headerSecAcceptCanonical     = "Sec-Websocket-Accept"
 )
 
 var (

--- a/http.go
+++ b/http.go
@@ -39,16 +39,18 @@ var (
 )
 
 var (
-	headerHost       = "Host"
-	headerUpgrade    = "Upgrade"
-	headerConnection = "Connection"
-
+	headerHost          = "Host"
+	headerUpgrade       = "Upgrade"
+	headerConnection    = "Connection"
 	headerSecVersion    = "Sec-WebSocket-Version"
 	headerSecProtocol   = "Sec-WebSocket-Protocol"
 	headerSecExtensions = "Sec-WebSocket-Extensions"
 	headerSecKey        = "Sec-WebSocket-Key"
 	headerSecAccept     = "Sec-WebSocket-Accept"
 
+	headerHostCanonical          = textproto.CanonicalMIMEHeaderKey("Host")
+	headerUpgradeCanonical       = textproto.CanonicalMIMEHeaderKey("Upgrade")
+	headerConnectionCanonical    = textproto.CanonicalMIMEHeaderKey("Connection")
 	headerSecVersionCanonical    = textproto.CanonicalMIMEHeaderKey(headerSecVersion)
 	headerSecProtocolCanonical   = textproto.CanonicalMIMEHeaderKey(headerSecProtocol)
 	headerSecExtensionsCanonical = textproto.CanonicalMIMEHeaderKey(headerSecExtensions)

--- a/server.go
+++ b/server.go
@@ -163,9 +163,9 @@ func (u HTTPUpgrader) Upgrade(r *http.Request, w http.ResponseWriter) (conn net.
 		err = ErrHandshakeBadUpgrade
 	} else if c := httpGetHeader(r.Header, headerConnection); c != "Upgrade" && !strHasToken(c, "upgrade") {
 		err = ErrHandshakeBadConnection
-	} else if nonce = httpGetHeader(r.Header, headerSecKey); len(nonce) != nonceSize {
+	} else if nonce = httpGetHeader(r.Header, headerSecKeyCanonical); len(nonce) != nonceSize {
 		err = ErrHandshakeBadSecKey
-	} else if v := httpGetHeader(r.Header, headerSecVersion); v != "13" {
+	} else if v := httpGetHeader(r.Header, headerSecVersionCanonical); v != "13" {
 		// According to RFC6455:
 		//
 		// If this version does not match a version understood by the server,
@@ -190,7 +190,7 @@ func (u HTTPUpgrader) Upgrade(r *http.Request, w http.ResponseWriter) (conn net.
 		}
 	}
 	if check := u.Protocol; err == nil && check != nil {
-		ps := r.Header[headerSecProtocol]
+		ps := r.Header[headerSecProtocolCanonical]
 		for i := 0; i < len(ps) && err == nil && hs.Protocol == ""; i++ {
 			var ok bool
 			hs.Protocol, ok = strSelectProtocol(ps[i], check)
@@ -200,7 +200,7 @@ func (u HTTPUpgrader) Upgrade(r *http.Request, w http.ResponseWriter) (conn net.
 		}
 	}
 	if check := u.Extension; err == nil && check != nil {
-		xs := r.Header[headerSecExtensions]
+		xs := r.Header[headerSecExtensionsCanonical]
 		for i := 0; i < len(xs) && err == nil; i++ {
 			var ok bool
 			hs.Extensions, ok = strSelectExtensions(xs[i], hs.Extensions, check)

--- a/server.go
+++ b/server.go
@@ -484,13 +484,13 @@ func (u Upgrader) Upgrade(conn io.ReadWriter) (hs Handshake, err error) {
 				err = ErrHandshakeBadConnection
 			}
 
-		case headerSecVersion:
+		case headerSecVersionCanonical:
 			headerSeen |= headerSeenSecVersion
 			if !bytes.Equal(v, specHeaderValueSecVersion) {
 				err = ErrHandshakeUpgradeRequired
 			}
 
-		case headerSecKey:
+		case headerSecKeyCanonical:
 			headerSeen |= headerSeenSecKey
 			if len(v) != nonceSize {
 				err = ErrHandshakeBadSecKey
@@ -498,7 +498,7 @@ func (u Upgrader) Upgrade(conn io.ReadWriter) (hs Handshake, err error) {
 				copy(nonce[:], v)
 			}
 
-		case headerSecProtocol:
+		case headerSecProtocolCanonical:
 			if custom, check := u.ProtocolCustom, u.Protocol; hs.Protocol == "" && (custom != nil || check != nil) {
 				var ok bool
 				if custom != nil {
@@ -511,7 +511,7 @@ func (u Upgrader) Upgrade(conn io.ReadWriter) (hs Handshake, err error) {
 				}
 			}
 
-		case headerSecExtensions:
+		case headerSecExtensionsCanonical:
 			if custom, check := u.ExtensionCustom, u.Extension; custom != nil || check != nil {
 				var ok bool
 				if custom != nil {

--- a/server.go
+++ b/server.go
@@ -159,9 +159,9 @@ func (u HTTPUpgrader) Upgrade(r *http.Request, w http.ResponseWriter) (conn net.
 		err = ErrHandshakeBadProtocol
 	} else if r.Host == "" {
 		err = ErrHandshakeBadHost
-	} else if u := httpGetHeader(r.Header, headerUpgrade); u != "websocket" && !strEqualFold(u, "websocket") {
+	} else if u := httpGetHeader(r.Header, headerUpgradeCanonical); u != "websocket" && !strEqualFold(u, "websocket") {
 		err = ErrHandshakeBadUpgrade
-	} else if c := httpGetHeader(r.Header, headerConnection); c != "Upgrade" && !strHasToken(c, "upgrade") {
+	} else if c := httpGetHeader(r.Header, headerConnectionCanonical); c != "Upgrade" && !strHasToken(c, "upgrade") {
 		err = ErrHandshakeBadConnection
 	} else if nonce = httpGetHeader(r.Header, headerSecKeyCanonical); len(nonce) != nonceSize {
 		err = ErrHandshakeBadSecKey
@@ -466,19 +466,19 @@ func (u Upgrader) Upgrade(conn io.ReadWriter) (hs Handshake, err error) {
 		}
 
 		switch btsToString(k) {
-		case headerHost:
+		case headerHostCanonical:
 			headerSeen |= headerSeenHost
 			if onHost := u.OnHost; onHost != nil {
 				err = onHost(v)
 			}
 
-		case headerUpgrade:
+		case headerUpgradeCanonical:
 			headerSeen |= headerSeenUpgrade
 			if !bytes.Equal(v, specHeaderValueUpgrade) && !btsEqualFold(v, specHeaderValueUpgrade) {
 				err = ErrHandshakeBadUpgrade
 			}
 
-		case headerConnection:
+		case headerConnectionCanonical:
 			headerSeen |= headerSeenConnection
 			if !bytes.Equal(v, specHeaderValueConnection) && !btsHasToken(v, specHeaderValueConnectionLower) {
 				err = ErrHandshakeBadConnection

--- a/server_test.go
+++ b/server_test.go
@@ -332,10 +332,10 @@ func TestHTTPUpgrader(t *testing.T) {
 				if test.badSecKey {
 					nonce = nonce[:nonceSize-1]
 				}
-				test.req.Header.Set(headerSecKey, string(nonce))
+				test.req.Header[headerSecKey] = []string{string(nonce)}
 			}
 			if test.err == nil {
-				test.res.Header.Set(headerSecAccept, string(makeAccept(test.nonce)))
+				test.res.Header[headerSecAccept] = []string{string(makeAccept(test.nonce))}
 			}
 
 			// Need to emulate http server read request for truth test.
@@ -398,10 +398,10 @@ func TestUpgrader(t *testing.T) {
 				if test.badSecKey {
 					nonce = nonce[:nonceSize-1]
 				}
-				test.req.Header.Set(headerSecKey, string(nonce))
+				test.req.Header[headerSecKey] = []string{string(nonce)}
 			}
 			if test.err == nil {
-				test.res.Header.Set(headerSecAccept, string(makeAccept(test.nonce)))
+				test.res.Header[headerSecAccept] = []string{string(makeAccept(test.nonce))}
 			}
 
 			u := Upgrader{


### PR DESCRIPTION
According to the RFC, the `Sec-WebSocket-*` headers should have a capital S inside the word WebSocket. This is a shame, because most other headers are canonicalized differently.

Some websocket servers are particularly picky about the capitalization. The [agar.io](https://agar.io/) server (or maybe the Cloudflare servers it's behind) will reject connections with the canonical spelling, giving a 400 in response.

You can try it. This will succeed:

    curl -v --http1.1 'https://live-arena-1cm5igj.agar.io/'
        -H 'Host: live-arena-1cm5igj.agar.io:443'
        -H 'Upgrade: websocket'
        -H 'Connection: Upgrade'
        -H 'Sec-WebSocket-Version: 13'
        -H 'Sec-WebSocket-Key: 1u4hDlp0kUjbZafgII9lLw=='

But this will fail, giving a 400 Bad Request:

    curl -v --http1.1 'https://live-arena-1cm5igj.agar.io/'
        -H 'Host: live-arena-1cm5igj.agar.io:443'
        -H 'Upgrade: websocket'
        -H 'Connection: Upgrade'
        -H 'Sec-Websocket-Version: 13'
        -H 'Sec-Websocket-Key: 1u4hDlp0kUjbZafgII9lLw=='

This patch fixes this: ws will now accept any capitalization it receives, but use the RFC-correct capitalization when sending headers either as a response or as an upgrade request.

Thanks for this library! The zero-copy functionality is really nice for us.