### PR TITLE
wsflate: initial commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,22 @@ bin/gocovmerge:
 
 .PHONY: autobahn
 autobahn: clean bin/reporter 
-	./autobahn/script/test.sh --build
+	./autobahn/script/test.sh --build --follow-logs
 	bin/reporter $(PWD)/autobahn/report/index.json
+
+.PHONY: autobahn/report
+autobahn/report: bin/reporter
+	./bin/reporter -http localhost:5555 ./autobahn/report/index.json
 
 test:
 	go test -coverprofile=ws.coverage .
 	go test -coverprofile=wsutil.coverage ./wsutil
+	go test -coverprofile=wsfalte.coverage ./wsflate
+	# No statemenets to cover in ./tests (there are only tests).
+	go test ./tests
 
 cover: bin/gocovmerge test autobahn
-	bin/gocovmerge ws.coverage wsutil.coverage autobahn/report/server.coverage > total.coverage
+	bin/gocovmerge ws.coverage wsutil.coverage wsflate.coverage autobahn/report/server.coverage > total.coverage
 
 benchcmp: BENCH_BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 benchcmp: BENCH_OLD:=$(shell mktemp -t old.XXXX)

--- a/README.md
+++ b/README.md
@@ -351,10 +351,100 @@ func main() {
 }
 ```
 
+# Compression
+
+There is a `ws/wsflate` package to support [Permessage-Deflate Compression
+Extension][rfc-pmce].
+
+It provides minimalistic I/O wrappers to be used in conjunction with any
+deflate implementation (for example, the standard library's
+[compress/flate][compress/flate].
+
+```go
+package main
+
+import (
+	"bytes"
+	"log"
+	"net"
+
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsflate"
+)
+
+func main() {
+	ln, err := net.Listen("tcp", "localhost:8080")
+	if err != nil {
+		// handle error
+	}
+	e := wsflate.Extension{
+		// We are using default parameters here since we use
+		// wsflate.{Compress,Decompress}Frame helpers below in the code.
+		// This assumes that we use standard compress/flate package as flate
+		// implementation.
+		Parameters: wsflate.DefaultParameters,
+	}
+	u := ws.Upgrader{
+		Negotiate: e.Negotiate,
+	}
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// Reset extension after previous upgrades.
+		e.Reset()
+
+		_, err = u.Upgrade(conn)
+		if err != nil {
+			log.Printf("upgrade error: %s", err)
+			continue
+		}
+		if _, ok := e.Accepted(); !ok {
+			log.Printf("didn't negotiate compression for %s", conn.RemoteAddr())
+			conn.Close()
+			continue
+		}
+
+		go func() {
+			defer conn.Close()
+			for {
+				frame, err := ws.ReadFrame(conn)
+				if err != nil {
+					// Handle error.
+					return
+				}
+				frame = ws.UnmaskFrameInPlace(frame)
+				frame, err = wsflate.DecompressFrame(frame)
+				if err != nil {
+					// Handle error.
+					return
+				}
+
+				// Do something with frame...
+
+				ack := ws.NewTextFrame([]byte("this is an acknowledgement"))
+				ack, err = wsflate.CompressFrame(ack)
+				if err != nil {
+					// Handle error.
+					return
+				}
+				if err = ws.WriteFrame(conn, ack); err != nil {
+					// Handle error.
+					return
+				}
+			}
+		}()
+	}
+}
+```
 
 
 [rfc-url]: https://tools.ietf.org/html/rfc6455
+[rfc-pmce]: https://tools.ietf.org/html/rfc7692#section-7
 [godoc-image]: https://godoc.org/github.com/gobwas/ws?status.svg
 [godoc-url]: https://godoc.org/github.com/gobwas/ws
 [travis-image]: https://travis-ci.org/gobwas/ws.svg?branch=master
 [travis-url]: https://travis-ci.org/gobwas/ws
+[compress/flate]: https://golang.org/pkg/compress/flate/

--- a/autobahn/config/fuzzingclient.json
+++ b/autobahn/config/fuzzingclient.json
@@ -1,24 +1,46 @@
 {
-   "outdir": "/report",
-   "servers": [
-      {
-		 "agent": "ws",
-         "url":   "ws://server:9001/ws"
-      },
-      {
-		 "agent": "wsutil",
-         "url":   "ws://server:9001/wsutil"
-      },
-      {
-		 "agent": "helpers/low",
-         "url":   "ws://server:9001/helpers/low"
-      },
-      {
-		 "agent": "helpers/high",
-         "url":   "ws://server:9001/helpers/high"
-      }
-   ],
-   "cases": ["*"],
-   "exclude-cases": [],
-   "exclude-agent-cases": {}
+	"outdir": "/report",
+	"servers": [
+		{
+			"agent": "ws",
+			"url":	"ws://ws-server:9001/ws"
+		},
+		{
+			"agent": "wsutil",
+			"url":	"ws://ws-server:9001/wsutil"
+		},
+		{
+			"agent": "helpers/low",
+			"url":	"ws://ws-server:9001/helpers/low"
+		},
+		{
+			"agent": "helpers/high",
+			"url":	"ws://ws-server:9001/helpers/high"
+		},
+		{
+			"agent": "wsflate",
+			"url":	"ws://ws-server:9001/wsflate"
+		}
+	],
+	"cases": ["*"],
+	"exclude-cases": [],
+	"exclude-agent-cases": {
+		"ws": [
+			"12.*", "13.*"
+		],
+		"wsutil": [
+			"12.*", "13.*"
+		],
+		"helpers/low": [
+			"12.*", "13.*"
+		],
+		"helpers/high": [
+			"12.*", "13.*"
+		],
+		"wsflate": [
+			"1.*","2.*","3.*", "4.*",
+			"5.*","6.*","7.*", "8.*",
+			"9.*","10.*","11.*"
+		]
+	}
 }

--- a/autobahn/script/test.sh
+++ b/autobahn/script/test.sh
@@ -13,16 +13,16 @@ while [[ $# -gt 0 ]]; do
 		--build)
 		case "$2" in
 			autobahn)
-				docker build . --file autobahn/docker/autobahn/Dockerfile --tag autobahn
+				docker build . --file autobahn/docker/autobahn/Dockerfile --tag ws-autobahn
 				shift
 			;;
 			server)
-				docker build . --file autobahn/docker/server/Dockerfile --tag server
+				docker build . --file autobahn/docker/server/Dockerfile --tag ws-server
 				shift
 			;;
 			*)
-				docker build . --file autobahn/docker/autobahn/Dockerfile --tag autobahn
-				docker build . --file autobahn/docker/server/Dockerfile --tag server
+				docker build . --file autobahn/docker/autobahn/Dockerfile --tag ws-autobahn
+				docker build . --file autobahn/docker/server/Dockerfile --tag ws-server
 			;;
 		esac
 		;;
@@ -64,10 +64,10 @@ with_prefix() {
 }
 
 random=$(xxd -l 4 -p /dev/random)
-server="${random}_server"
-autobahn="${random}_autobahn"
+server="${random}_ws-server"
+autobahn="${random}_ws-autobahn"
 
-network="ws-$random"
+network="ws-network-$random"
 docker network create --driver bridge "$network"
 if [ $? -ne 0 ]; then
 	exit 1
@@ -78,10 +78,10 @@ docker run \
 	--tty \
 	--detach \
 	--network="$network" \
-	--network-alias="server" \
+	--network-alias="ws-server" \
 	-v $(pwd)/autobahn/report:/report \
 	--name="$server" \
-	"server"
+	"ws-server"
 
 docker run \
 	--interactive \
@@ -91,12 +91,12 @@ docker run \
 	-v $(pwd)/autobahn/config:/config \
 	-v $(pwd)/autobahn/report:/report \
    	--name="$autobahn" \
-	"autobahn"
+	"ws-autobahn"
 
 
 if [[ $FOLLOW_LOGS -eq 1 ]]; then
-	(with_prefix "$(tput setaf 3)[autobahn]: $(tput sgr0)" docker logs --follow "$autobahn")&
-	(with_prefix "$(tput setaf 5)[server]:   $(tput sgr0)" docker logs --follow "$server")&
+	(with_prefix "$(tput setaf 3)[ws-autobahn]: $(tput sgr0)" docker logs --follow "$autobahn")&
+	(with_prefix "$(tput setaf 5)[ws-server]:   $(tput sgr0)" docker logs --follow "$server")&
 fi
 
 trap ctrl_c INT

--- a/dialer.go
+++ b/dialer.go
@@ -474,11 +474,18 @@ func matchSelectedExtensions(selected []byte, wanted, received []httphead.Option
 	index = -1
 	match := func() (ok bool) {
 		for _, want := range wanted {
-			if option.Equal(want) {
+			// A server accepts one or more extensions by including a
+			// |Sec-WebSocket-Extensions| header field containing one or more
+			// extensions that were requested by the client.
+			//
+			// The interpretation of any extension parameters, and what
+			// constitutes a valid response by a server to a requested set of
+			// parameters by a client, will be defined by each such extension.
+			if bytes.Equal(option.Name, want.Name) {
 				// Check parsed extension to be present in client
 				// requested extensions. We move matched extension
 				// from client list to avoid allocation.
-				received = append(received, want)
+				received = append(received, option)
 				return true
 			}
 		}

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -448,28 +448,6 @@ func TestDialerHandshake(t *testing.T) {
 			accept: acceptValid,
 			err:    ErrHandshakeBadExtensions,
 		},
-		{
-			name: "bad extensions",
-			dialer: Dialer{
-				Extensions: []httphead.Option{
-					httphead.NewOption("foo", map[string]string{
-						"bar": "1",
-					}),
-				},
-			},
-			res: &http.Response{
-				StatusCode: 101,
-				ProtoMajor: 1,
-				ProtoMinor: 1,
-				Header: http.Header{
-					headerConnection:    []string{"Upgrade"},
-					headerUpgrade:       []string{"websocket"},
-					headerSecExtensions: []string{"foo;bar=2"},
-				},
-			},
-			accept: acceptValid,
-			err:    ErrHandshakeBadExtensions,
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			client, server := net.Pipe()

--- a/example/autobahn/autobahn.go
+++ b/example/autobahn/autobahn.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"compress/flate"
 	"context"
 	"flag"
 	"fmt"
@@ -14,7 +15,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gobwas/httphead"
 	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsflate"
 	"github.com/gobwas/ws/wsutil"
 )
 
@@ -28,6 +31,7 @@ func main() {
 
 	http.HandleFunc("/ws", wsHandler)
 	http.HandleFunc("/wsutil", wsutilHandler)
+	http.HandleFunc("/wsflate", wsflateHandler)
 	http.HandleFunc("/helpers/low", helpersLowLevelHandler)
 	http.HandleFunc("/helpers/high", helpersHighLevelHandler)
 
@@ -174,8 +178,102 @@ func wsutilHandler(res http.ResponseWriter, req *http.Request) {
 	}
 }
 
+func wsflateHandler(w http.ResponseWriter, r *http.Request) {
+	e := wsflate.Extension{
+		Parameters: wsflate.Parameters{
+			ServerNoContextTakeover: true,
+			ClientNoContextTakeover: true,
+		},
+	}
+	u := ws.HTTPUpgrader{
+		Negotiate: e.Negotiate,
+	}
+	conn, _, _, err := u.Upgrade(r, w)
+	if err != nil {
+		log.Printf("upgrade error: %s", err)
+		return
+	}
+	defer conn.Close()
+
+	if _, ok := e.Accepted(); !ok {
+		log.Printf("no accepted extension")
+		return
+	}
+
+	// Using nil as a destination io.Writer since we will Reset() it in the
+	// loop below.
+	fw := wsflate.NewWriter(nil, func(w io.Writer) wsflate.Compressor {
+		// As flat.NewWriter() docs says:
+		//   If level is in the range [-2, 9] then the error returned will
+		//   be nil.
+		f, _ := flate.NewWriter(w, 9)
+		return f
+	})
+	// Using nil as a source io.Reader since we will Reset() it in the loop
+	// below.
+	fr := wsflate.NewReader(nil, func(r io.Reader) wsflate.Decompressor {
+		return flate.NewReader(r)
+	})
+	// Note that control frames are all written without compression.
+	controlHandler := wsutil.ControlFrameHandler(conn, ws.StateServerSide)
+	rd := wsutil.Reader{
+		Source:         conn,
+		State:          ws.StateServerSide | ws.StateExtended,
+		CheckUTF8:      false,
+		OnIntermediate: controlHandler,
+		Extensions: []wsutil.RecvExtension{
+			wsutil.RecvExtensionFunc(wsflate.BitsRecv),
+		},
+	}
+	wr := wsutil.Writer{
+		Dest:  conn,
+		State: ws.StateServerSide | ws.StateExtended,
+		Extensions: []wsutil.SendExtension{
+			wsutil.SendExtensionFunc(wsflate.BitsSend),
+		},
+	}
+	for {
+		h, err := rd.NextFrame()
+		if err != nil {
+			log.Printf("next frame error: %v", err)
+			return
+		}
+		if h.OpCode.IsControl() {
+			if err := controlHandler(h, &rd); err != nil {
+				log.Printf("handle control frame error: %v", err)
+				return
+			}
+			continue
+		}
+
+		fr.Reset(&rd)
+		fw.Reset(&wr)
+		wr.Op = h.OpCode
+
+		// Copy incoming bytes right into writer through decompressor and compressor.
+		if _, err = io.Copy(fw, fr); err != nil {
+			log.Fatal(err)
+		}
+		// Flush the flate writer.
+		if err = fw.Close(); err != nil {
+			log.Fatal(err)
+		}
+		// Flush WebSocket fragment writer. We could send multiple fragments
+		// for large messages.
+		if err = wr.Flush(); err != nil {
+			log.Fatal(err)
+		}
+	}
+}
+
 func wsHandler(w http.ResponseWriter, r *http.Request) {
-	conn, _, _, err := ws.UpgradeHTTP(r, w)
+	u := ws.HTTPUpgrader{
+		Extension: func(opt httphead.Option) bool {
+			log.Printf("extension: %s", opt)
+			return false
+		},
+	}
+	conn, _, _, err := u.Upgrade(r, w)
 	if err != nil {
 		log.Printf("upgrade error: %s", err)
 		return

--- a/frame.go
+++ b/frame.go
@@ -206,6 +206,28 @@ func (h Header) Rsv2() bool { return h.Rsv&bit6 != 0 }
 // Rsv3 reports whether the header has third rsv bit set.
 func (h Header) Rsv3() bool { return h.Rsv&bit7 != 0 }
 
+// Rsv creates rsv byte representation from bits.
+func Rsv(r1, r2, r3 bool) (rsv byte) {
+	if r1 {
+		rsv |= bit5
+	}
+	if r2 {
+		rsv |= bit6
+	}
+	if r3 {
+		rsv |= bit7
+	}
+	return rsv
+}
+
+// RsvBits returns rsv bits from bytes representation.
+func RsvBits(rsv byte) (r1, r2, r3 bool) {
+	r1 = rsv&bit5 != 0
+	r2 = rsv&bit6 != 0
+	r3 = rsv&bit7 != 0
+	return
+}
+
 // Frame represents websocket frame.
 // See https://tools.ietf.org/html/rfc6455#section-5.2
 type Frame struct {
@@ -377,20 +399,6 @@ func MustCompileFrame(f Frame) []byte {
 		panic(err)
 	}
 	return bts
-}
-
-// Rsv creates rsv byte representation.
-func Rsv(r1, r2, r3 bool) (rsv byte) {
-	if r1 {
-		rsv |= bit5
-	}
-	if r2 {
-		rsv |= bit6
-	}
-	if r3 {
-		rsv |= bit7
-	}
-	return rsv
 }
 
 func makeCloseFrame(code StatusCode) Frame {

--- a/server.go
+++ b/server.go
@@ -129,7 +129,22 @@ type HTTPUpgrader struct {
 	// Extension is the select function that is used to select extensions from
 	// list requested by client. If this field is set, then the all matched
 	// extensions are sent to a client as negotiated.
+	//
+	// DEPRECATED. Use Negotiate instead.
 	Extension func(httphead.Option) bool
+
+	// Negotiate is the callback that is used to negotiate extensions from
+	// the client's offer. If this field is set, then the returned non-zero
+	// extensions are sent to the client as accepted extensions in the
+	// response.
+	//
+	// The argument is only valid until the Negotiate callback returns.
+	//
+	// If returned error is non-nil then connection is rejected and response is
+	// sent with appropriate HTTP error code and body set to error message.
+	//
+	// RejectConnectionError could be used to get more control on response.
+	Negotiate func(httphead.Option) (httphead.Option, error)
 }
 
 // Upgrade upgrades http connection to the websocket connection.
@@ -200,11 +215,20 @@ func (u HTTPUpgrader) Upgrade(r *http.Request, w http.ResponseWriter) (conn net.
 			}
 		}
 	}
-	if check := u.Extension; err == nil && check != nil {
+	if f := u.Negotiate; err == nil && f != nil {
+		for _, h := range r.Header[headerSecExtensionsCanonical] {
+			hs.Extensions, err = negotiateExtensions(strToBytes(h), hs.Extensions, f)
+			if err != nil {
+				break
+			}
+		}
+	}
+	// DEPRECATED path.
+	if check := u.Extension; err == nil && check != nil && u.Negotiate == nil {
 		xs := r.Header[headerSecExtensionsCanonical]
 		for i := 0; i < len(xs) && err == nil; i++ {
 			var ok bool
-			hs.Extensions, ok = strSelectExtensions(xs[i], hs.Extensions, check)
+			hs.Extensions, ok = btsSelectExtensions(strToBytes(xs[i]), hs.Extensions, check)
 			if !ok {
 				err = ErrMalformedRequest
 			}
@@ -271,6 +295,9 @@ type Upgrader struct {
 	// from list requested by client. If this field is set, then the all matched
 	// extensions are sent to a client as negotiated.
 	//
+	// Note that Extension may be called multiple times and implementations
+	// must track uniqueness of accepted extensions manually.
+	//
 	// The argument is only valid until the callback returns.
 	//
 	// According to the RFC6455 order of extensions passed by a client is
@@ -283,12 +310,37 @@ type Upgrader struct {
 	// fields listed by the client in its request represent a preference of the
 	// header fields it wishes to use, with the first options listed being most
 	// preferable."
+	//
+	// DEPRECATED. Use Negotiate instead.
 	Extension func(httphead.Option) bool
 
-	// ExtensionCustom allow user to parse Sec-WebSocket-Extensions header manually.
+	// ExtensionCustom allow user to parse Sec-WebSocket-Extensions header
+	// manually.
+	//
+	// If ExtensionCustom() decides to accept received extension, it must
+	// append appropriate option to the given slice of httphead.Option.
+	// It returns results of append() to the given slice and a flag that
+	// reports whether given header value is wellformed or not.
+	//
+	// Note that ExtensionCustom may be called multiple times and
+	// implementations must track uniqueness of accepted extensions manually.
+	//
 	// Note that returned options should be valid until Upgrade returns.
 	// If ExtensionCustom is set, it used instead of Extension function.
 	ExtensionCustom func([]byte, []httphead.Option) ([]httphead.Option, bool)
+
+	// Negotiate is the callback that is used to negotiate extensions from
+	// the client's offer. If this field is set, then the returned non-zero
+	// extensions are sent to the client as accepted extensions in the
+	// response.
+	//
+	// The argument is only valid until the Negotiate callback returns.
+	//
+	// If returned error is non-nil then connection is rejected and response is
+	// sent with appropriate HTTP error code and body set to error message.
+	//
+	// RejectConnectionError could be used to get more control on response.
+	Negotiate func(httphead.Option) (httphead.Option, error)
 
 	// Header is an optional HandshakeHeader instance that could be used to
 	// write additional headers to the handshake response.
@@ -514,7 +566,11 @@ func (u Upgrader) Upgrade(conn io.ReadWriter) (hs Handshake, err error) {
 			}
 
 		case headerSecExtensionsCanonical:
-			if custom, check := u.ExtensionCustom, u.Extension; custom != nil || check != nil {
+			if f := u.Negotiate; err == nil && f != nil {
+				hs.Extensions, err = negotiateExtensions(v, hs.Extensions, f)
+			}
+			// DEPRECATED path.
+			if custom, check := u.ExtensionCustom, u.Extension; u.Negotiate == nil && (custom != nil || check != nil) {
 				var ok bool
 				if custom != nil {
 					hs.Extensions, ok = custom(v, hs.Extensions)

--- a/tests/deflate_test.go
+++ b/tests/deflate_test.go
@@ -1,0 +1,120 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gobwas/httphead"
+	"github.com/gobwas/ws"
+	"github.com/gobwas/ws/wsflate"
+	"github.com/gobwas/ws/wsutil"
+)
+
+func TestFlateClientServer(t *testing.T) {
+	e := wsflate.Extension{
+		Parameters: wsflate.DefaultParameters,
+	}
+	client, server := net.Pipe()
+
+	serverDone := make(chan error)
+	go func() {
+		defer func() {
+			client.Close()
+			close(serverDone)
+		}()
+		u := ws.Upgrader{
+			Negotiate: e.Negotiate,
+		}
+		_, err := u.Upgrade(client)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		var buf bytes.Buffer
+		for {
+			frame, err := ws.ReadFrame(client)
+			if err != nil {
+				serverDone <- err
+				return
+			}
+			frame = ws.UnmaskFrameInPlace(frame)
+			frame, err = wsflate.DecompressFrameBuffer(&buf, frame)
+			if err != nil {
+				serverDone <- err
+				return
+			}
+			echo := ws.NewTextFrame(reverse(frame.Payload))
+			if err := ws.WriteFrame(client, echo); err != nil {
+				serverDone <- err
+				return
+			}
+			buf.Reset()
+		}
+	}()
+
+	d := ws.Dialer{
+		Extensions: []httphead.Option{
+			e.Parameters.Option(),
+		},
+		NetDial: func(_ context.Context, network, addr string) (net.Conn, error) {
+			return server, nil
+		},
+	}
+	dd := wsutil.DebugDialer{
+		Dialer: d,
+		OnRequest: func(p []byte) {
+			t.Logf("Request:\n%s", p)
+		},
+		OnResponse: func(p []byte) {
+			t.Logf("Response:\n%s", p)
+		},
+	}
+	conn, _, _, err := dd.Dial(context.Background(), "ws://stubbed")
+	if err != nil {
+		t.Fatalf("unexpected Dial() error: %v", err)
+	}
+
+	payload := []byte("hello, deflate!")
+
+	frame := ws.NewTextFrame(payload)
+	frame, err = wsflate.CompressFrame(frame)
+	if err != nil {
+		t.Fatalf("can't compress frame: %v", err)
+	}
+	frame = ws.MaskFrameInPlace(frame)
+	if err := ws.WriteFrame(server, frame); err != nil {
+		t.Fatalf("unexpected WriteFrame() error: %v", err)
+	}
+
+	echo, err := ws.ReadFrame(server)
+	if err != nil {
+		t.Fatalf("unexpected ReadFrame() error: %v", err)
+	}
+	if !bytes.Equal(reverse(echo.Payload), payload) {
+		t.Fatalf("unexpected echoed bytes")
+	}
+
+	conn.Close()
+
+	const timeout = time.Second
+	select {
+	case <-time.After(timeout):
+		t.Fatalf("server goroutine timeout: %s", timeout)
+
+	case err := <-serverDone:
+		if err != io.EOF {
+			t.Fatalf("unexpected server goroutine error: %v", err)
+		}
+	}
+}
+
+func reverse(buf []byte) []byte {
+	for i, j := 0, len(buf)-1; i < j; i, j = i+1, j-1 {
+		buf[i], buf[j] = buf[j], buf[i]
+	}
+	return buf
+}

--- a/wsflate/cbuf.go
+++ b/wsflate/cbuf.go
@@ -1,0 +1,93 @@
+package wsflate
+
+import (
+	"io"
+)
+
+// cbuf is a tiny proxy-buffer that writes all but 4 last bytes to the
+// destination.
+type cbuf struct {
+	buf [4]byte
+	n   int
+	dst io.Writer
+	err error
+}
+
+// Write implements io.Writer interface.
+func (c *cbuf) Write(p []byte) (int, error) {
+	if c.err != nil {
+		return 0, c.err
+	}
+	head, tail := c.split(p)
+	n := c.n + len(tail)
+	if n > len(c.buf) {
+		x := n - len(c.buf)
+		c.flush(c.buf[:x])
+		copy(c.buf[:], c.buf[x:])
+		c.n -= x
+	}
+	if len(head) > 0 {
+		c.flush(head)
+	}
+	copy(c.buf[c.n:], tail)
+	c.n = min(c.n+len(tail), len(c.buf))
+	return len(p), c.err
+}
+
+func (c *cbuf) flush(p []byte) {
+	if c.err == nil {
+		_, c.err = c.dst.Write(p)
+	}
+}
+
+func (c *cbuf) split(p []byte) (head, tail []byte) {
+	if n := len(p); n > len(c.buf) {
+		x := n - len(c.buf)
+		head = p[:x]
+		tail = p[x:]
+		return
+	}
+	return nil, p
+}
+
+func (c *cbuf) reset(dst io.Writer) {
+	c.n = 0
+	c.err = nil
+	c.buf = [4]byte{0, 0, 0, 0}
+	c.dst = dst
+}
+
+type suffixedReader struct {
+	r      io.Reader
+	pos    int // position in the suffix.
+	suffix [9]byte
+}
+
+func (r *suffixedReader) Read(p []byte) (n int, err error) {
+	if r.r != nil {
+		n, err = r.r.Read(p)
+		if err == io.EOF {
+			err = nil
+			r.r = nil
+		}
+		return n, err
+	}
+	if r.pos >= len(r.suffix) {
+		return 0, io.EOF
+	}
+	n = copy(p, r.suffix[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func (r *suffixedReader) reset(src io.Reader) {
+	r.r = src
+	r.pos = 0
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/wsflate/cbuf_test.go
+++ b/wsflate/cbuf_test.go
@@ -1,0 +1,158 @@
+package wsflate
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"testing"
+)
+
+func TestSuffixReader(t *testing.T) {
+	for chunk := 1; chunk < 100; chunk++ {
+		var (
+			data = []byte("hello, flate!")
+			name = fmt.Sprintf("chunk-%d", chunk)
+		)
+		t.Run(name, func(t *testing.T) {
+			r := suffixedReader{
+				r: bytes.NewReader(data),
+				suffix: [9]byte{
+					1, 2, 3,
+					4, 5, 6,
+					7, 8, 9,
+				},
+			}
+			var (
+				act = make([]byte, 0, len(data)+len(r.suffix))
+				p   = make([]byte, chunk)
+			)
+			for len(act) < cap(act) {
+				n, err := r.Read(p)
+				act = append(act, p[:n]...)
+				if err == io.EOF {
+					break
+				}
+				if err != nil {
+					t.Fatalf("unexpected Read() error: %v", err)
+				}
+			}
+			exp := append(data, r.suffix[:]...)
+			if !bytes.Equal(act, exp) {
+				t.Fatalf("unexpected bytes read: %#q; want %#q", act, exp)
+			}
+		})
+	}
+}
+
+func TestCBuf(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		stream  [][]byte
+		expBody []byte
+		expTail []byte
+	}{
+		{
+			stream: [][]byte{
+				{1}, {2}, {3}, {4},
+			},
+			expTail: []byte{1, 2, 3, 4},
+		},
+		{
+			stream: [][]byte{
+				{1, 2}, {3, 4},
+			},
+			expTail: []byte{1, 2, 3, 4},
+		},
+		{
+			stream: [][]byte{
+				{1, 2, 3}, {4, 5, 6},
+			},
+			expBody: []byte{1, 2},
+			expTail: []byte{3, 4, 5, 6},
+		},
+		{
+			stream: [][]byte{
+				{1, 2, 3, 4}, {5, 6, 7, 8},
+			},
+			expBody: []byte{1, 2, 3, 4},
+			expTail: []byte{5, 6, 7, 8},
+		},
+		{
+			stream: [][]byte{
+				{1, 2, 3, 4, 5}, {6, 7, 8, 9, 10},
+			},
+			expBody: []byte{1, 2, 3, 4, 5, 6},
+			expTail: []byte{7, 8, 9, 10},
+		},
+		{
+			stream: [][]byte{
+				{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			},
+			expBody: []byte{1, 2, 3, 4, 5, 6},
+			expTail: []byte{7, 8, 9, 10},
+		},
+		{
+			name: "xxx",
+			stream: [][]byte{
+				{1, 2, 3, 4, 5}, {6},
+			},
+			expBody: []byte{1, 2},
+			expTail: []byte{3, 4, 5, 6},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := &cbuf{
+				dst: &buf,
+			}
+			for _, bts := range test.stream {
+				n, err := w.Write(bts)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if act, exp := n, len(bts); act != exp {
+					t.Fatalf(
+						"unexpected number of bytes written: %d; want %d",
+						act, exp,
+					)
+				}
+			}
+			if act, exp := w.buf[:], test.expTail; !bytes.Equal(act, exp) {
+				t.Errorf(
+					"unexpected tail: %v; want %v",
+					act, exp,
+				)
+			}
+			if act, exp := buf.Bytes(), test.expBody; !bytes.Equal(act, exp) {
+				t.Errorf(
+					"unexpected body: %v; want %v",
+					act, exp,
+				)
+			}
+		})
+	}
+}
+
+func BenchmarkCBuf(b *testing.B) {
+	for _, test := range []struct {
+		name  string
+		chunk []byte
+	}{
+		{
+			chunk: []byte{1, 2, 3, 4, 5},
+		},
+		{
+			chunk: []byte{1, 2, 3, 4},
+		},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			w := &cbuf{
+				dst: ioutil.Discard,
+			}
+			for i := 0; i < b.N; i++ {
+				w.Write(test.chunk)
+			}
+		})
+	}
+}

--- a/wsflate/extension.go
+++ b/wsflate/extension.go
@@ -1,0 +1,128 @@
+package wsflate
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/gobwas/httphead"
+	"github.com/gobwas/ws"
+)
+
+// Extension contains logic of compression extension parameters negotiation
+// made during HTTP WebSocket handshake.
+// It might be reused between different upgrades (but not concurrently) with
+// Reset() being called after each.
+type Extension struct {
+	// Parameters is specification of extension parameters server is going to
+	// accept.
+	Parameters Parameters
+
+	accepted bool
+	params   Parameters
+}
+
+// Negotiate parses given HTTP header option and returns (if any) header option
+// which describes accepted parameters.
+//
+// It may return zero option (i.e. one which Size() returns 0) alongside with
+// nil error.
+func (n *Extension) Negotiate(opt httphead.Option) (accept httphead.Option, err error) {
+	if !bytes.Equal(opt.Name, ExtensionNameBytes) {
+		return
+	}
+	if n.accepted {
+		// Negotiate might be called multiple times during upgrade.
+		// We stick to first one accepted extension since they must be passed
+		// in ordered by preference.
+		return
+	}
+
+	want := n.Parameters
+
+	// NOTE: Parse() resets params inside, so no worries.
+	if err = n.params.Parse(opt); err != nil {
+		return
+	}
+	{
+		offer := n.params.ServerMaxWindowBits
+		want := want.ServerMaxWindowBits
+		if offer > want {
+			// A server declines an extension negotiation offer
+			// with this parameter if the server doesn't support
+			// it.
+			return
+		}
+	}
+	{
+		// If a received extension negotiation offer has the
+		// "client_max_window_bits" extension parameter, the server MAY
+		// include the "client_max_window_bits" extension parameter in the
+		// corresponding extension negotiation response to the offer.
+		offer := n.params.ClientMaxWindowBits
+		want := want.ClientMaxWindowBits
+		if want > offer {
+			return
+		}
+	}
+	{
+		offer := n.params.ServerNoContextTakeover
+		want := want.ServerNoContextTakeover
+		if offer && !want {
+			return
+		}
+	}
+
+	n.accepted = true
+
+	return want.Option(), nil
+}
+
+// Accepted returns parameters parsed during last negotiation and a flag that
+// reports whether they were accepted.
+func (n *Extension) Accepted() (_ Parameters, accepted bool) {
+	return n.params, n.accepted
+}
+
+// Reset resets extension for further reuse.
+func (n *Extension) Reset() {
+	n.accepted = false
+	n.params = Parameters{}
+}
+
+var errNonFirstFragmentEnabledBit = ws.ProtocolError(
+	"non-first fragment contains compression bit enabled",
+)
+
+// BitsRecv changes RSV bits of the received frame header as if compression
+// extension was negotiated.
+func BitsRecv(fseq int, rsv byte) (byte, error) {
+	r1, r2, r3 := ws.RsvBits(rsv)
+	if fseq > 0 && r1 {
+		// An endpoint MUST NOT set the "Per-Message Compressed"
+		// bit of control frames and non-first fragments of a data
+		// message. An endpoint receiving such a frame MUST _Fail
+		// the WebSocket Connection_.
+		return rsv, errNonFirstFragmentEnabledBit
+	}
+	if fseq > 0 {
+		return rsv, nil
+	}
+	return ws.Rsv(false, r2, r3), nil
+}
+
+// BitsSend changes RSV bits of the frame header which is being send as if
+// compression extension was negotiated.
+func BitsSend(fseq int, rsv byte) (byte, error) {
+	r1, r2, r3 := ws.RsvBits(rsv)
+	if r1 {
+		return rsv, fmt.Errorf("wsflate: compression bit is already set")
+	}
+	if fseq > 0 {
+		// An endpoint MUST NOT set the "Per-Message Compressed"
+		// bit of control frames and non-first fragments of a data
+		// message. An endpoint receiving such a frame MUST _Fail
+		// the WebSocket Connection_.
+		return rsv, nil
+	}
+	return ws.Rsv(true, r2, r3), nil
+}

--- a/wsflate/helper.go
+++ b/wsflate/helper.go
@@ -1,0 +1,187 @@
+package wsflate
+
+import (
+	"bytes"
+	"compress/flate"
+	"fmt"
+	"io"
+
+	"github.com/gobwas/ws"
+)
+
+// DefaultHelper is a default helper instance holding standard library's
+// `compress/flate` compressor and decompressor under the hood.
+//
+// Note that use of DefaultHelper methods assumes that DefaultParameters were
+// used for extension negotiation during WebSocket handshake.
+var DefaultHelper = Helper{
+	Compressor: func(w io.Writer) Compressor {
+		// No error can be returned here as NewWriter() doc says.
+		f, _ := flate.NewWriter(w, 9)
+		return f
+	},
+	Decompressor: func(r io.Reader) Decompressor {
+		return flate.NewReader(r)
+	},
+}
+
+// DefaultParameters holds deflate extension parameters which are assumed by
+// DefaultHelper to be used during WebSocket handshake.
+var DefaultParameters = Parameters{
+	ServerNoContextTakeover: true,
+	ClientNoContextTakeover: true,
+}
+
+// CompressFrame is a shortcut for DefaultHelper.CompressFrame().
+//
+// Note that use of DefaultHelper methods assumes that DefaultParameters were
+// used for extension negotiation during WebSocket handshake.
+func CompressFrame(f ws.Frame) (ws.Frame, error) {
+	return DefaultHelper.CompressFrame(f)
+}
+
+// CompressFrameBuffer is a shortcut for DefaultHelper.CompressFrameBuffer().
+//
+// Note that use of DefaultHelper methods assumes that DefaultParameters were
+// used for extension negotiation during WebSocket handshake.
+func CompressFrameBuffer(buf Buffer, f ws.Frame) (ws.Frame, error) {
+	return DefaultHelper.CompressFrameBuffer(buf, f)
+}
+
+// DecompressFrame is a shortcut for DefaultHelper.DecompressFrame().
+//
+// Note that use of DefaultHelper methods assumes that DefaultParameters were
+// used for extension negotiation during WebSocket handshake.
+func DecompressFrame(f ws.Frame) (ws.Frame, error) {
+	return DefaultHelper.DecompressFrame(f)
+}
+
+// DecompressFrameBuffer is a shortcut for
+// DefaultHelper.DecompressFrameBuffer().
+//
+// Note that use of DefaultHelper methods assumes that DefaultParameters were
+// used for extension negotiation during WebSocket handshake.
+func DecompressFrameBuffer(buf Buffer, f ws.Frame) (ws.Frame, error) {
+	return DefaultHelper.DecompressFrameBuffer(buf, f)
+}
+
+// Helper is a helper struct that holds common code for compressing and
+// decompressing bytes or WebSocket frames.
+//
+// Its purpose is to reduce boilerplate code in WebSocket applications.
+type Helper struct {
+	Compressor   func(w io.Writer) Compressor
+	Decompressor func(r io.Reader) Decompressor
+}
+
+// Buffer is an interface representing some bytes buffering object.
+type Buffer interface {
+	io.Writer
+	Bytes() []byte
+}
+
+// CompressFrame returns compressed version of a frame.
+// Note that it does memory allocations internally. To control those
+// allocations consider using CompressFrameBuffer().
+func (h *Helper) CompressFrame(in ws.Frame) (f ws.Frame, err error) {
+	var buf bytes.Buffer
+	return h.CompressFrameBuffer(&buf, in)
+}
+
+// DecompressFrame returns decompressed version of a frame.
+// Note that it does memory allocations internally. To control those
+// allocations consider using DecompressFrameBuffer().
+func (h *Helper) DecompressFrame(in ws.Frame) (f ws.Frame, err error) {
+	var buf bytes.Buffer
+	return h.DecompressFrameBuffer(&buf, in)
+}
+
+// CompressFrameBuffer compresses a frame using given buffer.
+// Returned frame's payload holds bytes returned by buf.Bytes().
+func (h *Helper) CompressFrameBuffer(buf Buffer, in ws.Frame) (f ws.Frame, err error) {
+	if !in.Header.Fin {
+		return f, fmt.Errorf("wsflate: fragmented messages are not allowed")
+	}
+	if err := h.CompressTo(buf, in.Payload); err != nil {
+		return f, err
+	}
+	// Copy initial frame.
+	f = in
+	f.Payload = buf.Bytes()
+	f.Header.Length = int64(len(f.Payload))
+	f.Header.Rsv, err = BitsSend(0, f.Header.Rsv)
+	if err != nil {
+		return f, err
+	}
+	return f, nil
+}
+
+// DecompressFrameBuffer decompresses a frame using given buffer.
+// Returned frame's payload holds bytes returned by buf.Bytes().
+func (h *Helper) DecompressFrameBuffer(buf Buffer, in ws.Frame) (f ws.Frame, err error) {
+	if !in.Header.Fin {
+		return f, fmt.Errorf("wsflate: fragmented messages are not allowed")
+	}
+	if err := h.DecompressTo(buf, in.Payload); err != nil {
+		return f, err
+	}
+	// Copy initial frame.
+	f = in
+	f.Payload = buf.Bytes()
+	f.Header.Length = int64(len(f.Payload))
+	f.Header.Rsv, err = BitsRecv(0, f.Header.Rsv)
+	if err != nil {
+		return f, err
+	}
+	return f, nil
+}
+
+// Compress compresses given bytes.
+// Note that it does memory allocations internally. To control those
+// allocations consider using CompressTo().
+func (h *Helper) Compress(p []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := h.CompressTo(&buf, p); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Decompress decompresses given bytes.
+// Note that it does memory allocations internally. To control those
+// allocations consider using DecompressTo().
+func (h *Helper) Decompress(p []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := h.DecompressTo(&buf, p); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// CompressTo compresses bytes into given buffer.
+func (h *Helper) CompressTo(w io.Writer, p []byte) (err error) {
+	c := NewWriter(w, h.Compressor)
+	if _, err = c.Write(p); err != nil {
+		return err
+	}
+	if err = c.Flush(); err != nil {
+		return err
+	}
+	if err = c.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DecompressTo decompresses bytes into given buffer.
+// Returned bytes are bytes returned by buf.Bytes().
+func (h *Helper) DecompressTo(w io.Writer, p []byte) (err error) {
+	fr := NewReader(bytes.NewReader(p), h.Decompressor)
+	if _, err = io.Copy(w, fr); err != nil {
+		return err
+	}
+	if err = fr.Close(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/wsflate/parameters.go
+++ b/wsflate/parameters.go
@@ -1,0 +1,198 @@
+package wsflate
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/gobwas/httphead"
+)
+
+const (
+	ExtensionName = "permessage-deflate"
+
+	serverNoContextTakeover = "server_no_context_takeover"
+	clientNoContextTakeover = "client_no_context_takeover"
+	serverMaxWindowBits     = "server_max_window_bits"
+	clientMaxWindowBits     = "client_max_window_bits"
+)
+
+var (
+	ExtensionNameBytes = []byte(ExtensionName)
+
+	serverNoContextTakeoverBytes = []byte(serverNoContextTakeover)
+	clientNoContextTakeoverBytes = []byte(clientNoContextTakeover)
+	serverMaxWindowBitsBytes     = []byte(serverMaxWindowBits)
+	clientMaxWindowBitsBytes     = []byte(clientMaxWindowBits)
+)
+
+var windowBits [8][]byte
+
+func init() {
+	for i := range windowBits {
+		windowBits[i] = []byte(strconv.Itoa(i + 8))
+	}
+}
+
+// Parameters contains compressin extension options.
+type Parameters struct {
+	ServerNoContextTakeover bool
+	ClientNoContextTakeover bool
+	ServerMaxWindowBits     WindowBits
+	ClientMaxWindowBits     WindowBits
+}
+
+// WindowBits specifies window size accordingly to RFC.
+// Use its Bytes() method to obtain actual size of window in bytes.
+type WindowBits byte
+
+// Defined reports whether window bits were specified.
+func (b WindowBits) Defined() bool {
+	return b > 0
+}
+
+// Bytes returns window size in number of bytes.
+func (b WindowBits) Bytes() int {
+	return 1 << uint(b)
+}
+
+const (
+	MaxLZ77WindowSize = 32768 // 2^15
+)
+
+// Parse reads parameters from given HTTP header opiton accordingly to RFC.
+//
+// It returns non-nil error at least in these cases:
+//   - The negotiation offer contains an extension parameter not defined for
+//   use in an offer/response.
+//   - The negotiation offer/response contains an extension parameter with an
+//   invalid value.
+//   - The negotiation offer/response contains multiple extension parameters
+//   with
+// the same name.
+func (p *Parameters) Parse(opt httphead.Option) (err error) {
+	const (
+		clientMaxWindowBitsSeen = 1 << iota
+		serverMaxWindowBitsSeen
+		clientNoContextTakeoverSeen
+		serverNoContextTakeoverSeen
+	)
+
+	// Reset to not mix parsed data from previous Parse() calls.
+	*p = Parameters{}
+
+	var seen byte
+	opt.Parameters.ForEach(func(key, val []byte) (ok bool) {
+		switch string(key) {
+		case clientMaxWindowBits:
+			if len(val) == 0 {
+				p.ClientMaxWindowBits = 1
+				return true
+			}
+			if seen&clientMaxWindowBitsSeen != 0 {
+				err = paramError("duplicate", key, val)
+				return false
+			}
+			seen |= clientMaxWindowBitsSeen
+			if p.ClientMaxWindowBits, ok = bitsFromASCII(val); !ok {
+				err = paramError("invalid", key, val)
+				return false
+			}
+
+		case serverMaxWindowBits:
+			if len(val) == 0 {
+				err = paramError("invalid", key, val)
+				return false
+			}
+			if seen&serverMaxWindowBitsSeen != 0 {
+				err = paramError("duplicate", key, val)
+				return false
+			}
+			seen |= serverMaxWindowBitsSeen
+			if p.ServerMaxWindowBits, ok = bitsFromASCII(val); !ok {
+				err = paramError("invalid", key, val)
+				return false
+			}
+
+		case clientNoContextTakeover:
+			if len(val) > 0 {
+				err = paramError("invalid", key, val)
+				return false
+			}
+			if seen&clientNoContextTakeoverSeen != 0 {
+				err = paramError("duplicate", key, val)
+				return false
+			}
+			seen |= clientNoContextTakeoverSeen
+			p.ClientNoContextTakeover = true
+
+		case serverNoContextTakeover:
+			if len(val) > 0 {
+				err = paramError("invalid", key, val)
+				return false
+			}
+			if seen&serverNoContextTakeoverSeen != 0 {
+				err = paramError("duplicate", key, val)
+				return false
+			}
+			seen |= serverNoContextTakeoverSeen
+			p.ServerNoContextTakeover = true
+
+		default:
+			err = paramError("unexpected", key, val)
+			return false
+		}
+		return true
+	})
+	return
+}
+
+// Option encodes parameters into HTTP header option.
+func (p Parameters) Option() httphead.Option {
+	opt := httphead.Option{
+		Name: ExtensionNameBytes,
+	}
+	setBool(&opt, serverNoContextTakeoverBytes, p.ServerNoContextTakeover)
+	setBool(&opt, clientNoContextTakeoverBytes, p.ClientNoContextTakeover)
+	setBits(&opt, serverMaxWindowBitsBytes, p.ServerMaxWindowBits)
+	setBits(&opt, clientMaxWindowBitsBytes, p.ClientMaxWindowBits)
+	return opt
+}
+
+func isValidBits(x int) bool {
+	return 8 <= x && x <= 15
+}
+
+func bitsFromASCII(p []byte) (WindowBits, bool) {
+	n, ok := httphead.IntFromASCII(p)
+	if !ok || !isValidBits(n) {
+		return 0, false
+	}
+	return WindowBits(n), true
+}
+
+func setBits(opt *httphead.Option, name []byte, bits WindowBits) {
+	if bits == 0 {
+		return
+	}
+	if bits == 1 {
+		opt.Parameters.Set(name, nil)
+		return
+	}
+	if !isValidBits(int(bits)) {
+		panic(fmt.Sprintf("wsflate: invalid bits value: %d", bits))
+	}
+	opt.Parameters.Set(name, windowBits[bits-8])
+}
+
+func setBool(opt *httphead.Option, name []byte, flag bool) {
+	if flag {
+		opt.Parameters.Set(name, nil)
+	}
+}
+
+func paramError(reason string, key, val []byte) error {
+	return fmt.Errorf(
+		"wsflate: %s extension parameter %q: %q",
+		reason, key, val,
+	)
+}

--- a/wsflate/parameters_test.go
+++ b/wsflate/parameters_test.go
@@ -1,0 +1,1 @@
+package wsflate

--- a/wsflate/reader.go
+++ b/wsflate/reader.go
@@ -1,0 +1,83 @@
+package wsflate
+
+import (
+	"io"
+)
+
+// Decompressor is an interface holding deflate decompression implementation.
+type Decompressor interface {
+	io.Reader
+}
+
+// ReadResetter is an optional interface that Decompressor can implement.
+type ReadResetter interface {
+	Reset(io.Reader)
+}
+
+// Reader implements decompression from an io.Reader object using Decompressor.
+// Essentially Reader is a thin wrapper around Decompressor interface to meet
+// PMCE specs.
+//
+// After all data has been written client should call Flush() method.
+// If any error occurs after reading from Reader, all subsequent calls to
+// Read() or Close() will return the error.
+//
+// Reader might be reused for different io.Reader objects after its Reset()
+// method has been called.
+type Reader struct {
+	src  io.Reader
+	ctor func(io.Reader) Decompressor
+	d    Decompressor
+	sr   suffixedReader
+	err  error
+}
+
+// NewReader returns a new Reader.
+func NewReader(r io.Reader, ctor func(io.Reader) Decompressor) *Reader {
+	ret := &Reader{
+		src:  r,
+		ctor: ctor,
+		sr: suffixedReader{
+			suffix: compressionReadTail,
+		},
+	}
+	ret.Reset(r)
+	return ret
+}
+
+// Reset resets Reader to decompress data from src.
+func (r *Reader) Reset(src io.Reader) {
+	r.err = nil
+	r.src = src
+	r.sr.reset(src)
+	if x, ok := r.d.(ReadResetter); ok {
+		x.Reset(&r.sr)
+	} else {
+		r.d = r.ctor(&r.sr)
+	}
+}
+
+// Read implements io.Reader.
+func (r *Reader) Read(p []byte) (n int, err error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+	return r.d.Read(p)
+}
+
+// Close closes Reader and a Decompressor instance used under the hood (if it
+// implements io.Closer interface).
+func (r *Reader) Close() error {
+	if r.err != nil {
+		return r.err
+	}
+	if c, ok := r.d.(io.Closer); ok {
+		r.err = c.Close()
+	}
+	return r.err
+}
+
+// Err returns an error happened during any operation.
+func (r *Reader) Err() error {
+	return r.err
+}

--- a/wsflate/reader_test.go
+++ b/wsflate/reader_test.go
@@ -1,0 +1,1 @@
+package wsflate

--- a/wsflate/writer.go
+++ b/wsflate/writer.go
@@ -1,0 +1,129 @@
+package wsflate
+
+import (
+	"fmt"
+	"io"
+)
+
+var (
+	compressionTail = [4]byte{
+		0, 0, 0xff, 0xff,
+	}
+	compressionReadTail = [9]byte{
+		0, 0, 0xff, 0xff,
+		1,
+		0, 0, 0xff, 0xff,
+	}
+)
+
+// Compressor is an interface holding deflate compression implementation.
+type Compressor interface {
+	io.Writer
+	Flush() error
+}
+
+// WriteResetter is an optional interface that Compressor can implement.
+type WriteResetter interface {
+	Reset(io.Writer)
+}
+
+// Writer implements compression for an io.Writer object using Compressor.
+// Essentially Writer is a thin wrapper around Compressor interface to meet
+// PMCE specs.
+//
+// After all data has been written client should call Flush() method.
+// If any error occurs after writing to or flushing a Writer, all subsequent
+// calls to Write(), Flush() or Close() will return the error.
+//
+// Writer might be reused for different io.Writer objects after its Reset()
+// method has been called.
+type Writer struct {
+	// NOTE: Writer uses compressor constructor function instead of field to
+	// reach these goals:
+	// 	1. To shrink Compressor interface and make it easier to be implemented.
+	//	2. If used as a field (and argument to the NewWriter()), Compressor object
+	//	will probably be initialized twice - first time to pass into Writer, and
+	//	second time during Writer initialization (which does Reset() internally).
+	// 	3. To get rid of wrappers if Reset() would be a part of	Compressor.
+	// 	E.g. non conformant implementations would have to provide it somehow,
+	// 	probably making a wrapper with the same constructor function.
+	// 	4. To make Reader and Writer API the same. That is, there is no Reset()
+	// 	method for flate.Reader already, so we need to provide it as a wrapper
+	// 	(see point #3), or drop the Reader.Reset() method.
+	dest io.Writer
+	ctor func(io.Writer) Compressor
+	c    Compressor
+	cbuf cbuf
+	err  error
+}
+
+// NewWriter returns a new Writer.
+func NewWriter(w io.Writer, ctor func(io.Writer) Compressor) *Writer {
+	// NOTE: NewWriter() is chosen against structure with exported fields here
+	// due its Reset() method, which in case of structure, would change
+	// exported field.
+	ret := &Writer{
+		dest: w,
+		ctor: ctor,
+	}
+	ret.Reset(w)
+	return ret
+}
+
+// Reset resets Writer to compress data into dest.
+// Any not flushed data will be lost.
+func (w *Writer) Reset(dest io.Writer) {
+	w.err = nil
+	w.cbuf.reset(dest)
+	if x, ok := w.c.(WriteResetter); ok {
+		x.Reset(&w.cbuf)
+	} else {
+		w.c = w.ctor(&w.cbuf)
+	}
+}
+
+// Write implements io.Writer.
+func (w *Writer) Write(p []byte) (n int, err error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	n, w.err = w.c.Write(p)
+	return n, w.err
+}
+
+// Flush writes any pending data into w.Dest.
+func (w *Writer) Flush() error {
+	if w.err != nil {
+		return w.err
+	}
+	w.err = w.c.Flush()
+	w.checkTail()
+	return w.err
+}
+
+// Close closes Writer and a Compressor instance used under the hood (if it
+// implements io.Closer interface).
+func (w *Writer) Close() error {
+	if w.err != nil {
+		return w.err
+	}
+	if c, ok := w.c.(io.Closer); ok {
+		w.err = c.Close()
+	}
+	w.checkTail()
+	return w.err
+}
+
+// Err returns an error happened during any operation.
+func (w *Writer) Err() error {
+	return w.err
+}
+
+func (w *Writer) checkTail() {
+	if w.err == nil && w.cbuf.buf != compressionTail {
+		w.err = fmt.Errorf(
+			"wsflate: bad compressor: unexpected stream tail: %#x vs %#x",
+			w.cbuf.buf, compressionTail,
+		)
+	}
+}

--- a/wsflate/writer_test.go
+++ b/wsflate/writer_test.go
@@ -1,0 +1,121 @@
+package wsflate
+
+import (
+	"bytes"
+	"compress/flate"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/url"
+	"testing"
+
+	"github.com/gobwas/httphead"
+	"github.com/gobwas/ws"
+)
+
+func TestWriter(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(&buf, func(w io.Writer) Compressor {
+		fw, _ := flate.NewWriter(w, 9)
+		return fw
+	})
+	data := []byte("hello, flate!")
+	for _, p := range bytes.SplitAfter(data, []byte{','}) {
+		w.Write(p)
+		w.Flush()
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("unexpected Close() error: %v", err)
+	}
+	if err := w.Err(); err != nil {
+		t.Fatalf("unexpected Writer error: %v", err)
+	}
+
+	r := NewReader(&buf, func(r io.Reader) Decompressor {
+		return flate.NewReader(r)
+	})
+	act, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected Reader error: %v", err)
+	}
+	if exp := data; !bytes.Equal(act, exp) {
+		t.Fatalf("unexpected bytes: %#q; want %#q", act, exp)
+	}
+}
+
+func TestExtensionNegotiation(t *testing.T) {
+	client, server := net.Pipe()
+
+	done := make(chan error)
+	go func() {
+		defer close(done)
+		var (
+			req bytes.Buffer
+			res bytes.Buffer
+		)
+		conn := struct {
+			io.Reader
+			io.Writer
+		}{
+			io.TeeReader(server, &req),
+			io.MultiWriter(server, &res),
+		}
+		e := Extension{
+			Parameters: Parameters{
+				ServerNoContextTakeover: true,
+				ClientNoContextTakeover: true,
+			},
+		}
+		u := ws.Upgrader{
+			Negotiate: e.Negotiate,
+		}
+		hs, err := u.Upgrade(&conn)
+		if err != nil {
+			done <- err
+			return
+		}
+
+		p, ok := e.Accepted()
+		t.Logf("accepted: %t %+v", ok, p)
+
+		fmt.Println(req.String())
+		fmt.Println(res.String())
+		t.Logf("server: %+v", hs)
+	}()
+
+	d := ws.Dialer{
+		Extensions: []httphead.Option{
+			(Parameters{
+				ServerNoContextTakeover: true,
+				ClientNoContextTakeover: true,
+				ClientMaxWindowBits:     8,
+				ServerMaxWindowBits:     10,
+			}).Option(),
+			(Parameters{
+				ClientMaxWindowBits: 1,
+			}).Option(),
+			(Parameters{}).Option(),
+		},
+	}
+
+	uri, err := url.Parse("ws://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, hs, err := d.Upgrade(client, uri)
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if n := len(hs.Extensions); n != 1 {
+		t.Fatalf("unexpected number of accepted extensions: %d", n)
+	}
+	var p Parameters
+	if err := p.Parse(hs.Extensions[0]); err != nil {
+		t.Fatalf("parse extension error: %v", err)
+	}
+	t.Logf("client params: %+v", p)
+	if err := <-done; err != nil {
+		t.Fatalf("server Upgrade() error: %v", err)
+	}
+}

--- a/wsutil/extenstion.go
+++ b/wsutil/extenstion.go
@@ -1,0 +1,29 @@
+package wsutil
+
+// RecvExtension is an interface for clearing fragment header RSV bits.
+type RecvExtension interface {
+	BitsRecv(seq int, rsv byte) (byte, error)
+}
+
+// RecvExtensionFunc is an adapter to allow the use of ordinary functions as
+// RecvExtension.
+type RecvExtensionFunc func(int, byte) (byte, error)
+
+// BitsRecv implements RecvExtension.
+func (fn RecvExtensionFunc) BitsRecv(seq int, rsv byte) (byte, error) {
+	return fn(seq, rsv)
+}
+
+// SendExtension is an interface for setting fragment header RSV bits.
+type SendExtension interface {
+	BitsSend(seq int, rsv byte) (byte, error)
+}
+
+// SendExtensionFunc is an adapter to allow the use of ordinary functions as
+// SendExtension.
+type SendExtensionFunc func(int, byte) (byte, error)
+
+// BitsSend implements SendExtension.
+func (fn SendExtensionFunc) BitsSend(seq int, rsv byte) (byte, error) {
+	return fn(seq, rsv)
+}

--- a/wsutil/reader.go
+++ b/wsutil/reader.go
@@ -37,6 +37,11 @@ type Reader struct {
 	// bytes are not valid UTF-8 sequence, ErrInvalidUTF8 returned.
 	CheckUTF8 bool
 
+	// Extensions is a list of negotiated extensions for reader Source.
+	// It is used to meet the specs and clear appropriate bits in fragment
+	// header RSV segment.
+	Extensions []RecvExtension
+
 	// TODO(gobwas): add max frame size limit here.
 
 	OnContinuation FrameHandlerFunc
@@ -46,6 +51,7 @@ type Reader struct {
 	frame  io.Reader        // Used to as frame reader.
 	raw    io.LimitedReader // Used to discard frames without cipher.
 	utf8   UTF8Reader       // Used to check UTF8 sequences if CheckUTF8 is true.
+	fseq   int              // Fragment sequence in message counter.
 }
 
 // NewReader creates new frame reader that reads from r keeping given state to
@@ -100,9 +106,10 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 		return
 	}
 	if err == nil && r.raw.N != 0 {
-		return
+		return n, nil
 	}
 
+	// EOF condition (either err is io.EOF or r.raw.N is zero).
 	switch {
 	case r.raw.N != 0:
 		err = io.ErrUnexpectedEOF
@@ -112,6 +119,8 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 		r.resetFragment()
 
 	case r.CheckUTF8 && !r.utf8.Valid():
+		// NOTE: check utf8 only when full message received, since partial
+		// reads may be invalid.
 		n = r.utf8.Accepted()
 		err = ErrInvalidUTF8
 
@@ -168,12 +177,23 @@ func (r *Reader) NextFrame() (hdr ws.Header, err error) {
 
 	// Save raw reader to use it on discarding frame without ciphering and
 	// other streaming checks.
-	r.raw = io.LimitedReader{r.Source, hdr.Length}
+	r.raw = io.LimitedReader{
+		R: r.Source,
+		N: hdr.Length,
+	}
 
 	frame := io.Reader(&r.raw)
 	if hdr.Masked {
 		frame = NewCipherReader(frame, hdr.Mask)
 	}
+
+	for _, ext := range r.Extensions {
+		hdr.Rsv, err = ext.BitsRecv(r.fseq, hdr.Rsv)
+		if err != nil {
+			return hdr, err
+		}
+	}
+
 	if r.fragmented() {
 		if hdr.OpCode.IsControl() {
 			if cb := r.OnIntermediate; cb != nil {
@@ -204,8 +224,10 @@ func (r *Reader) NextFrame() (hdr ws.Header, err error) {
 
 	if hdr.Fin {
 		r.State = r.State.Clear(ws.StateFragmented)
+		r.fseq = 0
 	} else {
 		r.State = r.State.Set(ws.StateFragmented)
+		r.fseq++
 	}
 
 	return
@@ -226,6 +248,7 @@ func (r *Reader) reset() {
 	r.raw = io.LimitedReader{}
 	r.frame = nil
 	r.utf8 = UTF8Reader{}
+	r.fseq = 0
 	r.opCode = 0
 }
 

--- a/wsutil/writer.go
+++ b/wsutil/writer.go
@@ -378,7 +378,7 @@ func (w *Writer) WriteThrough(p []byte) (n int, err error) {
 		frame.Payload = p
 	}
 
-	w.err = ws.WriteFrame(w, frame)
+	w.err = ws.WriteFrame(w.dest, frame)
 	if w.err == nil {
 		n = len(p)
 	}

--- a/wsutil/writer.go
+++ b/wsutil/writer.go
@@ -366,6 +366,12 @@ func (w *Writer) WriteThrough(p []byte) (n int, err error) {
 		Fin:    false,
 		Length: int64(len(p)),
 	}
+	for _, ext := range w.extensions {
+		frame.Header.Rsv, err = ext.BitsSend(w.fseq, frame.Header.Rsv)
+		if err != nil {
+			return 0, err
+		}
+	}
 	if w.state.ClientSide() {
 		// Should copy bytes to prevent corruption of caller data.
 		payload := pbytes.GetLen(len(p))

--- a/wsutil/writer_test.go
+++ b/wsutil/writer_test.go
@@ -544,7 +544,7 @@ func frames(p []byte) (ret []ws.Frame) {
 func pretty(f ...ws.Frame) string {
 	str := "\n"
 	for _, f := range f {
-		str += fmt.Sprintf("\t%#v\n\t%#x (%s)\n\t----\n", f.Header, f.Payload, f.Payload)
+		str += fmt.Sprintf("\t%#v\n\t%#x (%#q)\n\t----\n", f.Header, f.Payload, f.Payload)
 	}
 	return str
 }


### PR DESCRIPTION
This is an implementation of [WebSocket Per-Message Compression Extensions](https://tools.ietf.org/html/rfc7692).
The main ideas behind this implementation are:
- ability to use any deflate library user wants (maybe with fallback to standard libary's compression/flate package, which is used to pass the Autobahn tests). 
- zero coupling between ws/wsutil/wsflate packages*

> However, several changes where needed in all of three packages. But all of them are not aware of any specific extension. That is, some any new extension probably might be used with that changes (or with minimum tweaks).

Things to do:

- [x] Implement PMCE parameters negotiation.
- [x] Implement library-agnostic Reader/Writer structs to follow RFC for compression _in general_.
- [x] Pass the Autobahn test suite.
- [x] Check that API is extendable (e.g. for multiple extensions) and easy to use.
- [x] Decide whether we need some helpers to compress whole `ws.Frame`. This will probably lead to allocations inside such functions. Maybe good example in docs will be enough and user can write such helper on its own to have more control on allocations and buffers reuse (when needed).
- [x] More tests (probably with testable examples).
- [x] Update README.md.