### PR TITLE
added option for dialer to follow redirects

### DIFF
--- a/http.go
+++ b/http.go
@@ -42,6 +42,7 @@ var (
 	headerHost          = "Host"
 	headerUpgrade       = "Upgrade"
 	headerConnection    = "Connection"
+	headerLocation      = "Location"
 	headerSecVersion    = "Sec-WebSocket-Version"
 	headerSecProtocol   = "Sec-WebSocket-Protocol"
 	headerSecExtensions = "Sec-WebSocket-Extensions"
@@ -51,6 +52,7 @@ var (
 	headerHostCanonical          = textproto.CanonicalMIMEHeaderKey(headerHost)
 	headerUpgradeCanonical       = textproto.CanonicalMIMEHeaderKey(headerUpgrade)
 	headerConnectionCanonical    = textproto.CanonicalMIMEHeaderKey(headerConnection)
+	headerLocationCanonical      = textproto.CanonicalMIMEHeaderKey(headerLocation)
 	headerSecVersionCanonical    = textproto.CanonicalMIMEHeaderKey(headerSecVersion)
 	headerSecProtocolCanonical   = textproto.CanonicalMIMEHeaderKey(headerSecProtocol)
 	headerSecExtensionsCanonical = textproto.CanonicalMIMEHeaderKey(headerSecExtensions)


### PR DESCRIPTION
Hey guys,
First of all, thank you for this package! Great job!

This PR introduces ability for a client to follow redirects.

Protocol wise, following redirects is [acceptable](https://tools.ietf.org/html/rfc6455#section-4.1).
Previous behaviour is unmodified

Usage:
Simply add `dialer.FollowRedirects = true`

This is quite a naive implementation.
If you feel changes are required to make it more acceptable, I would happily put the time in.