### PR TITLE
Fix bugs in the Grow feature

### DIFF
--- a/wsutil/handler.go
+++ b/wsutil/handler.go
@@ -150,10 +150,7 @@ func (c ControlHandler) HandleClose(h ws.Header) error {
 	}
 
 	// Prepare bytes both for reading reason and sending response.
-	p := pbytes.GetLen(int(h.Length) + ws.HeaderSize(ws.Header{
-		Length: h.Length,
-		Masked: c.State.ClientSide(),
-	}))
+	p := pbytes.GetLen(int(h.Length) + reserve(c.State))
 	defer pbytes.Put(p)
 
 	// Get the subslice to read the frame payload out.

--- a/wsutil/handler.go
+++ b/wsutil/handler.go
@@ -81,10 +81,7 @@ func (c ControlHandler) HandlePing(h ws.Header) error {
 	}
 
 	// In other way reply with Pong frame with copied payload.
-	p := pbytes.GetLen(int(h.Length) + ws.HeaderSize(ws.Header{
-		Length: h.Length,
-		Masked: c.State.ClientSide(),
-	}))
+	p := pbytes.GetLen(int(h.Length) + reserve(c.State))
 	defer pbytes.Put(p)
 
 	// Deal with ciphering i/o:

--- a/wsutil/handler_test.go
+++ b/wsutil/handler_test.go
@@ -34,6 +34,11 @@ func TestControlHandler(t *testing.T) {
 			out:   ws.NewPongFrame([]byte("catch the ball")),
 		},
 		{
+			name: "ping",
+			in:   ws.NewPingFrame(bytes.Repeat([]byte{0xfe}, 125)),
+			out:  ws.NewPongFrame(bytes.Repeat([]byte{0xfe}, 125)),
+		},
+		{
 			name:  "pong",
 			in:    ws.NewPongFrame(nil),
 			noOut: true,
@@ -62,6 +67,19 @@ func TestControlHandler(t *testing.T) {
 			err: ClosedError{
 				Code:   ws.StatusGoingAway,
 				Reason: "goodbye!",
+			},
+		},
+		{
+			name: "close",
+			in: ws.NewCloseFrame(ws.NewCloseFrameBody(
+				ws.StatusGoingAway, "bye",
+			)),
+			out: ws.NewCloseFrame(ws.NewCloseFrameBody(
+				ws.StatusGoingAway, "",
+			)),
+			err: ClosedError{
+				Code:   ws.StatusGoingAway,
+				Reason: "bye",
 			},
 		},
 		{

--- a/wsutil/writer.go
+++ b/wsutil/writer.go
@@ -290,7 +290,7 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 	var nn int
 	for len(p) > w.Available() && w.err == nil {
 		if w.noFlush {
-			w.Grow(len(p) - w.Available())
+			w.Grow(len(p))
 			continue
 		}
 		if w.Buffered() == 0 {

--- a/wsutil/writer.go
+++ b/wsutil/writer.go
@@ -57,7 +57,7 @@ func NewControlWriter(dest io.Writer, state ws.State, op ws.OpCode) *ControlWrit
 //
 // It panics if len(buf) <= ws.MinHeaderSize + x.
 func NewControlWriterBuffer(dest io.Writer, state ws.State, op ws.OpCode, buf []byte) *ControlWriter {
-	max := ws.MaxControlFramePayloadSize + headerSize(state, ws.MaxControlFramePayloadSize)
+	max := ws.MaxControlFramePayloadSize + reserve(state)
 	if len(buf) > max {
 		buf = buf[:max]
 	}

--- a/wsutil/writer_test.go
+++ b/wsutil/writer_test.go
@@ -399,6 +399,10 @@ func TestWriterGrow(t *testing.T) {
 			name:     "buffer grow leads to its reduce",
 			dataSize: 20,
 		},
+		{
+			name:     "header size increases",
+			dataSize: int(len16) + 10,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/wsutil/writer_test.go
+++ b/wsutil/writer_test.go
@@ -45,14 +45,14 @@ func TestControlWriter(t *testing.T) {
 			exp:   ws.NewPingFrame([]byte("0123456789")),
 		},
 		{
-			size:  10 + reserve(server, 10),
+			size:  10 + reserve(server),
 			write: []byte("0123456789"),
 			state: server,
 			op:    ws.OpPing,
 			exp:   ws.NewPingFrame([]byte("0123456789")),
 		},
 		{
-			size:  10 + reserve(server, 10),
+			size:  10 + reserve(server),
 			write: []byte("0123456789a"),
 			state: server,
 			op:    ws.OpPing,
@@ -143,12 +143,12 @@ var reserveTestCases = []reserveTestCase{
 	{
 		name:      "len7",
 		buf:       int(len7) + 2,
-		expOffset: 2,
+		expOffset: 10,
 	},
 	{
 		name:      "len16",
 		buf:       int(len16) + 4,
-		expOffset: 4,
+		expOffset: 10,
 	},
 	{
 		name:      "maxint",
@@ -159,13 +159,13 @@ var reserveTestCases = []reserveTestCase{
 		name:      "len7 masked",
 		buf:       int(len7) + 6,
 		state:     ws.StateClientSide,
-		expOffset: 6,
+		expOffset: 14,
 	},
 	{
 		name:      "len16 masked",
 		buf:       int(len16) + 8,
 		state:     ws.StateClientSide,
-		expOffset: 8,
+		expOffset: 14,
 	},
 	{
 		name:      "maxint masked",
@@ -176,7 +176,7 @@ var reserveTestCases = []reserveTestCase{
 	{
 		name:      "split case",
 		buf:       128,
-		expOffset: 4,
+		expOffset: 10,
 	},
 }
 
@@ -195,12 +195,12 @@ func TestNewWriterBuffer(t *testing.T) {
 			panic: true,
 		},
 	)
-	cases = append(cases, genReserveTestCases(0, int(len7)-2, int(len7)+2, 2)...)
-	cases = append(cases, genReserveTestCases(0, int(len16)-4, int(len16)+4, 4)...)
+	cases = append(cases, genReserveTestCases(0, int(len7)-2, int(len7)+2, 10)...)
+	cases = append(cases, genReserveTestCases(0, int(len16)-4, int(len16)+4, 10)...)
 	cases = append(cases, genReserveTestCases(0, maxint-10, maxint, 10)...)
 
-	cases = append(cases, genReserveTestCases(ws.StateClientSide, int(len7)-6, int(len7)+6, 6)...)
-	cases = append(cases, genReserveTestCases(ws.StateClientSide, int(len16)-8, int(len16)+8, 8)...)
+	cases = append(cases, genReserveTestCases(ws.StateClientSide, int(len7)-6, int(len7)+6, 14)...)
+	cases = append(cases, genReserveTestCases(ws.StateClientSide, int(len16)-8, int(len16)+8, 14)...)
 	cases = append(cases, genReserveTestCases(ws.StateClientSide, maxint-14, maxint, 14)...)
 
 	for _, test := range cases {


### PR DESCRIPTION
Thanks for your excellent work!

https://github.com/chromedp/chromedp depends on this package, and it fails to send large requests due to the lack of fragmentation support in Chrome (reported here: https://github.com/ChromeDevTools/devtools-protocol/issues/175). Now that `Grow()` is added to this package, I want to address this issue on the client side. It works like a charm! Thank you very much!

I found some issues though. So here is the pull request.

BTW, `DisableFlush()` is supposed to be used to enable auto growing of the buffer, right? Is it better to call it `EnableAutoGrow()`?