### PR TITLE
wsflate: avoid double buffering when using flate.Reader

### DIFF
--- a/wsflate/reader.go
+++ b/wsflate/reader.go
@@ -50,10 +50,11 @@ func (r *Reader) Reset(src io.Reader) {
 	r.err = nil
 	r.src = src
 	r.sr.reset(src)
+
 	if x, ok := r.d.(ReadResetter); ok {
-		x.Reset(&r.sr)
+		x.Reset(r.sr.iface())
 	} else {
-		r.d = r.ctor(&r.sr)
+		r.d = r.ctor(r.sr.iface())
 	}
 }
 

--- a/wsflate/reader_test.go
+++ b/wsflate/reader_test.go
@@ -1,1 +1,37 @@
 package wsflate
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestSuffixedReaderIface(t *testing.T) {
+	for _, test := range []struct {
+		src io.Reader
+		exp bool
+	}{
+		{
+			src: bytes.NewReader(nil),
+			exp: true,
+		},
+		{
+			src: io.TeeReader(nil, nil),
+			exp: false,
+		},
+	} {
+		t.Run(fmt.Sprintf("%T", test.src), func(t *testing.T) {
+			isByteReader := func(r io.Reader) bool {
+				_, ok := r.(io.ByteReader)
+				return ok
+			}
+			s := &suffixedReader{
+				r: test.src,
+			}
+			if act, exp := isByteReader(s.iface()), test.exp; act != exp {
+				t.Fatalf("unexpected io.ByteReader: %t; want %t", act, exp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit makes wsflate.suffixedReader to optionally implement
io.ByteReader. That is, if source object is buffered (bytes.Reader,
bufio.Reader etc.) and implements io.ByteReader, but suffixedReader not,
then flate.NewReader() will allocate new bufio.Reader for it. This
commit fixes it and adds runtime checks on suffixedReader source to hide
ReadByte() method if source is a pure io.Reader.

Fixes #130