### PR TITLE
Expose a func to construct header data

### DIFF
--- a/write.go
+++ b/write.go
@@ -47,6 +47,18 @@ func HeaderSize(h Header) (n int) {
 
 // WriteHeader writes header binary representation into w.
 func WriteHeader(w io.Writer, h Header) error {
+	headerData, err := MakeHeaderData(h)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(headerData)
+
+	return err
+}
+
+// MakeHeaderData construct header data for websocket frame
+func MakeHeaderData(h Header) ([]byte, error) {
 	// Make slice of bytes with capacity 14 that could hold any header.
 	bts := make([]byte, MaxHeaderSize)
 
@@ -73,7 +85,7 @@ func WriteHeader(w io.Writer, h Header) error {
 		n = 10
 
 	default:
-		return ErrHeaderLengthUnexpected
+		return nil, ErrHeaderLengthUnexpected
 	}
 
 	if h.Masked {
@@ -81,9 +93,7 @@ func WriteHeader(w io.Writer, h Header) error {
 		n += copy(bts[n:], h.Mask[:])
 	}
 
-	_, err := w.Write(bts[:n])
-
-	return err
+	return bts[:n], nil
 }
 
 // WriteFrame writes frame binary representation into w.


### PR DESCRIPTION
Hi,your ws package helped me a lot! Thank you!

I use this [netpoll](https://github.com/cloudwego/netpoll) replace mailru/easygo/netpoll.

I need a func to construct header data like this
![image](https://user-images.githubusercontent.com/31007143/184325330-8dbe451b-0db2-4551-b1ea-5df75d704d19.png)

Thank again

=== RUN   TestWriteHeader
=== RUN   TestWriteHeader/#0
=== RUN   TestWriteHeader/#1
=== RUN   TestWriteHeader/#2
=== RUN   TestWriteHeader/#3
--- PASS: TestWriteHeader (0.00s)
    --- PASS: TestWriteHeader/#0 (0.00s)
    --- PASS: TestWriteHeader/#1 (0.00s)
    --- PASS: TestWriteHeader/#2 (0.00s)
    --- PASS: TestWriteHeader/#3 (0.00s)
PASS
ok      github.com/gobwas/ws    0.002s