### PR TITLE
ws: bring back support for go1.16

### DIFF
--- a/util_purego.go
+++ b/util_purego.go
@@ -1,4 +1,5 @@
 //go:build purego
+// +build purego
 
 package ws
 

--- a/util_unsafe.go
+++ b/util_unsafe.go
@@ -1,4 +1,5 @@
 //go:build !purego
+// +build !purego
 
 package ws
 


### PR DESCRIPTION
Running `go1.16 build .` failed with:

    //go:build comment without // +build comment

Fixes chromedp/chromedp#1310.