### PR TITLE
ws,wsutil: use t.Fatal instead of panic

### DIFF
--- a/cipher_test.go
+++ b/cipher_test.go
@@ -91,8 +91,7 @@ func TestCipherChops(t *testing.T) {
 					l, r := j-s, j
 					Cipher(b[l:r], m, l)
 					if !reflect.DeepEqual(b[l:r], exp[l:r]) {
-						t.Errorf("unexpected Cipher([%d:%d]) = %x; want %x", l, r, b[l:r], exp[l:r])
-						return
+						t.Fatalf("unexpected Cipher([%d:%d]) = %x; want %x", l, r, b[l:r], exp[l:r])
 					}
 				}
 			}
@@ -103,8 +102,7 @@ func TestCipherChops(t *testing.T) {
 				r := rand.Intn(n-l) + l + 1
 				Cipher(b[l:r], m, l)
 				if !reflect.DeepEqual(b[l:r], exp[l:r]) {
-					t.Errorf("unexpected Cipher([%d:%d]):\nact:\t%v\nexp:\t%v\nact:\t%#x\nexp:\t%#x\n\n", l, r, b[l:r], exp[l:r], b[l:r], exp[l:r])
-					return
+					t.Fatalf("unexpected Cipher([%d:%d]):\nact:\t%v\nexp:\t%v\nact:\t%#x\nexp:\t%#x\n\n", l, r, b[l:r], exp[l:r], b[l:r], exp[l:r])
 				}
 				l = r
 			}

--- a/dialer_test.go
+++ b/dialer_test.go
@@ -101,8 +101,7 @@ func TestDialerRequest(t *testing.T) {
 				t.Errorf("unexpected request:\nact:\n%s\nexp:\n%s\n", act, exp)
 			}
 			if _, err := http.ReadRequest(bufio.NewReader(&buf)); err != nil {
-				t.Errorf("read request error: %s", err)
-				return
+				t.Fatalf("read request error: %s", err)
 			}
 		})
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -394,21 +394,19 @@ func TestHTTPUpgrader(t *testing.T) {
 			}
 			_, _, hs, err := u.Upgrade(req, res)
 			if test.err != err {
-				t.Errorf(
+				t.Fatalf(
 					"expected error to be '%v', got '%v';\non request:\n====\n%s\n====",
 					test.err, err, dumpRequest(req),
 				)
-				return
 			}
 
 			actRespBts := sortHeaders(res.Bytes())
 			expRespBts := sortHeaders(dumpResponse(test.res))
 			if !bytes.Equal(actRespBts, expRespBts) {
-				t.Errorf(
+				t.Fatalf(
 					"unexpected http response:\n---- act:\n%s\n---- want:\n%s\n==== on request:\n%s\n====",
 					actRespBts, expRespBts, dumpRequest(test.req),
 				)
-				return
 			}
 
 			if act, exp := hs.Protocol, test.hs.Protocol; act != exp {
@@ -458,19 +456,16 @@ func TestUpgrader(t *testing.T) {
 
 			hs, err := u.Upgrade(conn)
 			if test.err != err {
-
-				t.Errorf("expected error to be '%v', got '%v'", test.err, err)
-				return
+				t.Fatalf("expected error to be '%v', got '%v'", test.err, err)
 			}
 
 			actRespBts := sortHeaders(conn.Bytes())
 			expRespBts := sortHeaders(dumpResponse(test.res))
 			if !bytes.Equal(actRespBts, expRespBts) {
-				t.Errorf(
+				t.Fatalf(
 					"unexpected http response:\n---- act:\n%s\n---- want:\n%s\n==== on request:\n%s\n====",
 					actRespBts, expRespBts, dumpRequest(test.req),
 				)
-				return
 			}
 
 			if act, exp := hs.Protocol, test.hs.Protocol; act != exp {

--- a/wsutil/cipher_test.go
+++ b/wsutil/cipher_test.go
@@ -38,12 +38,10 @@ func TestCipherReader(t *testing.T) {
 
 			bts, err := ioutil.ReadAll(rd)
 			if err != nil {
-				t.Errorf("unexpected error: %s", err)
-				return
+				t.Fatalf("unexpected error: %s", err)
 			}
 			if !reflect.DeepEqual(bts, test.data) {
-				t.Errorf("read data is not equal:\n\tact:\t%#v\n\texp:\t%#x\n", bts, test.data)
-				return
+				t.Fatalf("read data is not equal:\n\tact:\t%#v\n\texp:\t%#x\n", bts, test.data)
 			}
 		})
 	}

--- a/wsutil/helper_test.go
+++ b/wsutil/helper_test.go
@@ -26,7 +26,7 @@ func TestReadMessageEOF(t *testing.T) {
 				var buf bytes.Buffer
 				f := ws.NewTextFrame([]byte("this part will be lost"))
 				if err := ws.WriteHeader(&buf, f.Header); err != nil {
-					panic(err)
+					t.Fatal(err)
 				}
 				return &buf
 			},
@@ -44,7 +44,7 @@ func TestReadMessageEOF(t *testing.T) {
 				}
 				for _, f := range fs {
 					if err := ws.WriteFrame(&buf, f); err != nil {
-						panic(err)
+						t.Fatal(err)
 					}
 				}
 				return &buf

--- a/wsutil/reader_test.go
+++ b/wsutil/reader_test.go
@@ -105,7 +105,7 @@ func TestReaderNextFrameAndReadEOF(t *testing.T) {
 				var buf bytes.Buffer
 				f := ws.NewTextFrame([]byte("this part will be lost"))
 				if err := ws.WriteHeader(&buf, f.Header); err != nil {
-					panic(err)
+					t.Fatal(err)
 				}
 				return &buf
 			},
@@ -117,7 +117,7 @@ func TestReaderNextFrameAndReadEOF(t *testing.T) {
 				var buf bytes.Buffer
 				f := ws.NewTextFrame([]byte("foobar"))
 				if err := ws.WriteHeader(&buf, f.Header); err != nil {
-					panic(err)
+					t.Fatal(err)
 				}
 				buf.WriteString("foo")
 				return &buf
@@ -130,7 +130,7 @@ func TestReaderNextFrameAndReadEOF(t *testing.T) {
 				var buf bytes.Buffer
 				f := ws.NewFrame(ws.OpText, false, []byte("payload"))
 				if err := ws.WriteFrame(&buf, f); err != nil {
-					panic(err)
+					t.Fatal(err)
 				}
 				return &buf
 			},
@@ -197,7 +197,7 @@ func TestMaxFrameSize(t *testing.T) {
 func TestReaderUTF8(t *testing.T) {
 	yo := []byte("Ё")
 	if !utf8.ValidString(string(yo)) {
-		panic("bad fixture")
+		t.Fatal("bad fixture")
 	}
 
 	var buf bytes.Buffer
@@ -324,8 +324,7 @@ func TestNextReader(t *testing.T) {
 				bts, err = ioutil.ReadAll(reader)
 			}
 			if err != test.err {
-				t.Errorf("unexpected error; got %v; want %v", err, test.err)
-				return
+				t.Fatalf("unexpected error; got %v; want %v", err, test.err)
 			}
 			if test.err == nil && !bytes.Equal(bts, test.exp) {
 				t.Errorf(

--- a/wsutil/utf8_test.go
+++ b/wsutil/utf8_test.go
@@ -151,20 +151,16 @@ func TestUTF8Reader(t *testing.T) {
 				}
 			}
 			if test.err && err == nil {
-				t.Errorf("want error; got nil")
-				return
+				t.Fatalf("want error; got nil")
 			}
 			if !test.err && err != nil {
-				t.Errorf("unexpected error: %s", err)
-				return
+				t.Fatalf("unexpected error: %s", err)
 			}
 			if test.err && err == ErrInvalidUTF8 && i != test.at {
-				t.Errorf("received error at %d; want at %d", i, test.at)
-				return
+				t.Fatalf("received error at %d; want at %d", i, test.at)
 			}
 			if act, exp := r.Valid(), test.valid; act != exp {
-				t.Errorf("Valid() = %v; want %v", act, exp)
-				return
+				t.Fatalf("Valid() = %v; want %v", act, exp)
 			}
 			if !test.err && !bytes.Equal(bts, data) {
 				t.Errorf("bytes are not equal")


### PR DESCRIPTION
This PR replaces `panic(err)` with `t.Fatal(err)` where possible in `wsutil` tests. Also, replace `t.Error(err); return` with `t.Fatal(err)`.