### PR TITLE
Hijack connection through `http.ResponseController` in http upgrader

### DIFF
--- a/hijack_go119.go
+++ b/hijack_go119.go
@@ -1,0 +1,18 @@
+//go:build !go1.20
+// +build !go1.20
+
+package ws
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+)
+
+func hijack(w http.ResponseWriter) (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := w.(http.Hijacker)
+	if ok {
+		return hj.Hijack()
+	}
+	return nil, nil, ErrNotHijacker
+}

--- a/hijack_go120.go
+++ b/hijack_go120.go
@@ -1,0 +1,19 @@
+//go:build go1.20
+// +build go1.20
+
+package ws
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+)
+
+func hijack(w http.ResponseWriter) (net.Conn, *bufio.ReadWriter, error) {
+	conn, rw, err := http.NewResponseController(w).Hijack()
+	if errors.Is(err, http.ErrNotSupported) {
+		return nil, nil, ErrNotHijacker
+	}
+	return conn, rw, err
+}

--- a/server.go
+++ b/server.go
@@ -155,12 +155,7 @@ type HTTPUpgrader struct {
 func (u HTTPUpgrader) Upgrade(r *http.Request, w http.ResponseWriter) (conn net.Conn, rw *bufio.ReadWriter, hs Handshake, err error) {
 	// Hijack connection first to get the ability to write rejection errors the
 	// same way as in Upgrader.
-	hj, ok := w.(http.Hijacker)
-	if ok {
-		conn, rw, err = hj.Hijack()
-	} else {
-		err = ErrNotHijacker
-	}
+	conn, rw, err = hijack(w)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)
 		return conn, rw, hs, err


### PR DESCRIPTION
Go 1.20 introduced new and more convenient way to control response and discover features -  [ResponseController](https://pkg.go.dev/net/http#ResponseController). It's methods can introspect middlewares implementing following interface 
```go
type rwUnwrapper interface {
	Unwrap() ResponseWriter
}
```
[source](https://cs.opensource.google/go/go/+/refs/tags/go1.20.1:src/net/http/responsecontroller.go;l=66)

This PR contains changes to use it if go version newer than 1.20. Old behaviour will be used if go version is older than 1.20.
