### PR TITLE
Use new `unsafe` functions introduced in go 1.20

### DIFF
--- a/util_unsafe_119.go
+++ b/util_unsafe_119.go
@@ -1,5 +1,5 @@
-//go:build !purego
-// +build !purego
+//go:build !purego && !go1.20
+// +build !purego,!go1.20
 
 package ws
 

--- a/util_unsafe_120.go
+++ b/util_unsafe_120.go
@@ -1,0 +1,14 @@
+//go:build !purego && go1.20
+// +build !purego,go1.20
+
+package ws
+
+import "unsafe"
+
+func strToBytes(str string) (bts []byte) {
+	return unsafe.Slice(unsafe.StringData(str), len(str))
+}
+
+func btsToString(bts []byte) (str string) {
+	return unsafe.String(&bts[0], len(bts))
+}

--- a/wsutil/writer_test.go
+++ b/wsutil/writer_test.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
-	"unsafe"
 
 	"github.com/gobwas/ws"
 )
@@ -131,15 +130,6 @@ func genReserveTestCases(s ws.State, n, m, exp int) []reserveTestCase {
 	return ret
 }
 
-func fakeMake(n int) (r []byte) {
-	rh := (*reflect.SliceHeader)(unsafe.Pointer(&r))
-	*rh = reflect.SliceHeader{
-		Len: n,
-		Cap: n,
-	}
-	return r
-}
-
 var reserveTestCases = []reserveTestCase{
 	{
 		name:      "len7",
@@ -215,7 +205,7 @@ func TestNewWriterBuffer(t *testing.T) {
 					t.Errorf("unexpected panic: %v", thePanic)
 				}
 			}()
-			w := NewWriterBuffer(nil, test.state, 0, fakeMake(test.buf))
+			w := NewWriterBuffer(nil, test.state, 0, make([]byte, test.buf))
 			if act, exp := len(w.raw)-len(w.buf), test.expOffset; act != exp {
 				t.Errorf(
 					"NewWriteBuffer(%d bytes) has offset %d; want %d",


### PR DESCRIPTION
This eliminates usage of deprecated and error prone `reflect.SliceHeader` and `reflect.StringHeader`. Backwards compatibility saved with build tags