### PR TITLE
dialer: support custom Host header

### DIFF
--- a/dialer_test.go
+++ b/dialer_test.go
@@ -46,12 +46,14 @@ func TestDialerRequest(t *testing.T) {
 					httphead.NewOption("baz", nil),
 				},
 				Header: HandshakeHeaderHTTP(http.Header{
-					"Origin": []string{"who knows"},
+					headerHost: []string{"www.example.org"},
+					"Origin":   []string{"who knows"},
 				}),
 			},
 			url: "wss://example.org/chat",
 			exp: setProto(1, 1,
 				mustMakeRequest("GET", "wss://example.org/chat", http.Header{
+					headerHost:       []string{"www.example.org"},
 					headerUpgrade:    []string{"websocket"},
 					headerConnection: []string{"Upgrade"},
 					headerSecVersion: []string{"13"},

--- a/http.go
+++ b/http.go
@@ -291,7 +291,19 @@ func httpWriteUpgradeRequest(
 	bw.WriteString(u.RequestURI())
 	bw.WriteString(" HTTP/1.1\r\n")
 
-	httpWriteHeader(bw, headerHost, u.Host)
+	var host string
+	if httpHandshakeHeader, isHTTP := header.(HandshakeHeaderHTTP); isHTTP {
+		httpHeader := http.Header(httpHandshakeHeader)
+		if customHost := httpHeader.Get("Host"); customHost != "" {
+			host = customHost
+			httpHeader.Del("Host")
+		}
+	}
+	if host == "" {
+		host = u.Host
+	}
+
+	httpWriteHeader(bw, headerHost, host)
 
 	httpWriteHeaderBts(bw, headerUpgrade, specHeaderValueUpgrade)
 	httpWriteHeaderBts(bw, headerConnection, specHeaderValueConnection)

--- a/server_test.go
+++ b/server_test.go
@@ -760,6 +760,9 @@ func mustMakeRequest(method, url string, headers http.Header) *http.Request {
 	if err != nil {
 		panic(err)
 	}
+	if host := headers.Get("Host"); host != "" {
+		req.Host = host
+	}
 	req.Header = headers
 	return req
 }


### PR DESCRIPTION
The existing dialer forces the use of url.Host as the Host header, it would be better if customization is allowed.