### PR TITLE
Drop Go 1.15 support on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '1.15', 'stable', 'oldstable' ]
+        go: [ 'stable', 'oldstable' ]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Go 1.15 isn't supported anymore, no sense to test against it.