### PR TITLE
Cipher 1.9x speedup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '1.20.x', '1.21.x', '1.22.x' ]
+        go: [ '1.15', 'stable', 'oldstable' ]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,7 +42,17 @@ jobs:
       run: |
         go mod verify
 
+    - name: Test Go 1.15
+      # This step if needed because -shuffle not available on Go 1.15.
+      # Tests are failing on MacOS. So, we just disable it.
+      if: >-
+        matrix.go == '1.15' && matrix.os != 'macos-latest'
+      run: |
+        go test -v -race -cover ./...
+
     - name: Test
+      if: >-
+        matrix.go != '1.15'
       run: |
         go test -v -race -shuffle=on -cover ./...
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go: [ '1.15', 'stable', 'oldstable' ]
+        go: [ '1.20.x', '1.21.x', '1.22.x' ]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -42,17 +42,7 @@ jobs:
       run: |
         go mod verify
 
-    - name: Test Go 1.15
-      # This step if needed because -shuffle not available on Go 1.15.
-      # Tests are failing on MacOS. So, we just disable it.
-      if: >-
-        matrix.go == '1.15' && matrix.os != 'macos-latest'
-      run: |
-        go test -v -race -cover ./...
-
     - name: Test
-      if: >-
-        matrix.go != '1.15'
       run: |
         go test -v -race -shuffle=on -cover ./...
 

--- a/cipher.go
+++ b/cipher.go
@@ -25,7 +25,7 @@ func Cipher(payload []byte, mask [4]byte, offset int) {
 	// Count number of bytes will processed one by one from the beginning of payload.
 	ln := remain[mpos]
 	// Count number of bytes will processed one by one from the end of payload.
-	// This is done to process payload by 8 bytes in each iteration of main loop.
+	// This is done to process payload by 16 bytes in each iteration of main loop.
 	rn := (n - ln) % 16
 
 	for i := 0; i < ln; i++ {

--- a/cipher.go
+++ b/cipher.go
@@ -26,7 +26,7 @@ func Cipher(payload []byte, mask [4]byte, offset int) {
 	ln := remain[mpos]
 	// Count number of bytes will processed one by one from the end of payload.
 	// This is done to process payload by 8 bytes in each iteration of main loop.
-	rn := (n - ln) % 8
+	rn := (n - ln) % 16
 
 	for i := 0; i < ln; i++ {
 		payload[i] ^= mask[(mpos+i)%4]
@@ -44,15 +44,15 @@ func Cipher(payload []byte, mask [4]byte, offset int) {
 	)
 	// Skip already processed right part.
 	// Get number of uint64 parts remaining to process.
-	n = (n - ln - rn) >> 3
+	n = (n - ln - rn) >> 4
+	j := ln
 	for i := 0; i < n; i++ {
-		var (
-			j     = ln + (i << 3)
-			chunk = payload[j : j+8]
-		)
-		p := binary.LittleEndian.Uint64(chunk)
-		p = p ^ m2
+		chunk := payload[j : j+16]
+		p := binary.LittleEndian.Uint64(chunk) ^ m2
+		p2 := binary.LittleEndian.Uint64(chunk[8:]) ^ m2
 		binary.LittleEndian.PutUint64(chunk, p)
+		binary.LittleEndian.PutUint64(chunk[8:], p2)
+		j += 16
 	}
 }
 

--- a/cipher_test.go
+++ b/cipher_test.go
@@ -169,6 +169,8 @@ func BenchmarkCipher(b *testing.B) {
 
 		b.Run(fmt.Sprintf("naive_bytes=%d;offset=%d", bench.size, bench.offset), func(b *testing.B) {
 			var sink int64
+			b.SetBytes(int64(bench.size))
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				r := cipherNaiveNoCp(bts, mask, bench.offset)
 				sink += int64(len(r))
@@ -177,6 +179,8 @@ func BenchmarkCipher(b *testing.B) {
 		})
 		b.Run(fmt.Sprintf("bytes=%d;offset=%d", bench.size, bench.offset), func(b *testing.B) {
 			var sink int64
+			b.SetBytes(int64(bench.size))
+			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				Cipher(bts, mask, bench.offset)
 				sink += int64(len(bts))


### PR DESCRIPTION
Simplify cipher loop and unroll once.

```
λ benchcmp before.txt after.txt | grep -v "naive"
benchmark                                          old ns/op     new ns/op     delta
BenchmarkCipher/bytes=7;offset=1-32                7.17          7.79          +8.65%
BenchmarkCipher/bytes=125;offset=0-32              24.5          23.1          -6.07%
BenchmarkCipher/bytes=1024;offset=0-32             126           63.4          -49.87%
BenchmarkCipher/bytes=4096;offset=0-32             462           244           -47.26%
BenchmarkCipher/bytes=4100;offset=4-32             460           249           -45.93%
BenchmarkCipher/bytes=4099;offset=3-32             463           250           -45.93%
BenchmarkCipher/bytes=32775;offset=49-32           3619          1936          -46.50%

benchmark                                          old MB/s     new MB/s     speedup
BenchmarkCipher/bytes=7;offset=1-32                976.74       898.93       0.92x
BenchmarkCipher/bytes=125;offset=0-32              5092.84      5423.57      1.06x
BenchmarkCipher/bytes=1024;offset=0-32             8103.00      16159.29     1.99x
BenchmarkCipher/bytes=4096;offset=0-32             8870.86      16818.08     1.90x
BenchmarkCipher/bytes=4100;offset=4-32             8917.63      16491.32     1.85x
BenchmarkCipher/bytes=4099;offset=3-32             8854.38      16379.58     1.85x
BenchmarkCipher/bytes=32775;offset=49-32           9056.37      16926.83     1.87x
```

I tried a few variations, but this seemed fine without too many changes.