### PR TITLE
Allow buffer reuse in ReadHeader/WriteHeader variants.

### DIFF
--- a/read.go
+++ b/read.go
@@ -21,6 +21,18 @@ func ReadHeader(r io.Reader) (h Header, err error) {
 	// So 14 - 2 = 12.
 	bts := make([]byte, 2, MaxHeaderSize-2)
 
+	return ReadHeaderBuffer(r, bts)
+}
+
+// ReadHeaderBuffer reads a frame header from r using user-provided buffer.
+// Provided buffer must be at least 12 bytes long.
+func ReadHeaderBuffer(r io.Reader, bts []byte) (h Header, err error) {
+	if cap(bts) < MaxHeaderSize-2 {
+		return h, io.ErrShortBuffer
+	}
+
+	bts = bts[:2]
+
 	// Prepare to hold first 2 bytes to choose size of next read.
 	_, err = io.ReadFull(r, bts)
 	if err != nil {

--- a/write.go
+++ b/write.go
@@ -50,11 +50,23 @@ func WriteHeader(w io.Writer, h Header) error {
 	// Make slice of bytes with capacity 14 that could hold any header.
 	bts := make([]byte, MaxHeaderSize)
 
+	return WriteHeaderBuffer(w, h, bts)
+}
+
+// WriteHeaderBuffer writes header binary representation into w using user-provided buffer.
+// Provided buffer must be at least 14 bytes long.
+func WriteHeaderBuffer(w io.Writer, h Header, bts []byte) error {
+	if cap(bts) < MaxHeaderSize {
+		return io.ErrShortBuffer
+	}
+
+	bts = bts[:MaxHeaderSize]
+
+	bts[0] = h.Rsv<<4 | byte(h.OpCode)
+
 	if h.Fin {
 		bts[0] |= bit0
 	}
-	bts[0] |= h.Rsv << 4
-	bts[0] |= byte(h.OpCode)
 
 	var n int
 	switch {

--- a/write_test.go
+++ b/write_test.go
@@ -31,8 +31,24 @@ func TestWriteHeader(t *testing.T) {
 func BenchmarkWriteHeader(b *testing.B) {
 	for _, bench := range RWBenchCases {
 		b.Run(bench.label, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
 			for i := 0; i < b.N; i++ {
 				if err := WriteHeader(ioutil.Discard, bench.header); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run("reused-buffer-"+bench.label, func(b *testing.B) {
+			bts := make([]byte, MaxHeaderSize)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				if err := WriteHeaderBuffer(ioutil.Discard, bench.header, bts); err != nil {
 					b.Fatal(err)
 				}
 			}


### PR DESCRIPTION
Currently each `ReadHeader`/`WriteHeader` call incurs allocation penalty. This MR allows user to provide own buffer to those calls by adding `ReadHeaderBuffer`/`WriteHeaderBuffer`  variants.

Benchmarks:

<details>
<summary>ReadHeader</summary>

```
goos: linux
goarch: amd64
pkg: github.com/gobwas/ws
cpu: AMD Ryzen 7 PRO 8840U w/ Radeon 780M Graphics  
BenchmarkReadHeader
BenchmarkReadHeader/no-mask#0
BenchmarkReadHeader/no-mask#0-16         	54530907	        21.27 ns/op	      16 B/op	       1 allocs/op
BenchmarkReadHeader/reused-buffer-no-mask#0
BenchmarkReadHeader/reused-buffer-no-mask#0-16         	152444149	         7.811 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadHeader/mask#1
BenchmarkReadHeader/mask#1-16                          	46440010	        23.27 ns/op	      16 B/op	       1 allocs/op
BenchmarkReadHeader/reused-buffer-mask#1
BenchmarkReadHeader/reused-buffer-mask#1-16            	74732881	        14.33 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadHeader/mask-u16#2
BenchmarkReadHeader/mask-u16#2-16                      	46687669	        23.77 ns/op	      16 B/op	       1 allocs/op
BenchmarkReadHeader/reused-buffer-mask-u16#2
BenchmarkReadHeader/reused-buffer-mask-u16#2-16        	72172458	        15.00 ns/op	       0 B/op	       0 allocs/op
BenchmarkReadHeader/mask-u64#3
BenchmarkReadHeader/mask-u64#3-16                      	42360039	        24.57 ns/op	      16 B/op	       1 allocs/op
BenchmarkReadHeader/reused-buffer-mask-u64#3
BenchmarkReadHeader/reused-buffer-mask-u64#3-16        	71174119	        15.51 ns/op	       0 B/op	       0 allocs/op
PASS
```
</details>

<details>
<summary>WriteHeader</summary>

```
goos: linux
goarch: amd64
pkg: github.com/gobwas/ws
cpu: AMD Ryzen 7 PRO 8840U w/ Radeon 780M Graphics  
BenchmarkWriteHeader
BenchmarkWriteHeader/no-mask
BenchmarkWriteHeader/no-mask-16         	80543956	        14.90 ns/op	      16 B/op	       1 allocs/op
BenchmarkWriteHeader/reused-buffer-no-mask
BenchmarkWriteHeader/reused-buffer-no-mask-16         	338765588	         3.562 ns/op	       0 B/op	       0 allocs/op
BenchmarkWriteHeader/mask
BenchmarkWriteHeader/mask-16                          	78015270	        15.51 ns/op	      16 B/op	       1 allocs/op
BenchmarkWriteHeader/reused-buffer-mask
BenchmarkWriteHeader/reused-buffer-mask-16            	294887298	         3.994 ns/op	       0 B/op	       0 allocs/op
BenchmarkWriteHeader/mask-u16
BenchmarkWriteHeader/mask-u16-16                      	70865414	        15.52 ns/op	      16 B/op	       1 allocs/op
BenchmarkWriteHeader/reused-buffer-mask-u16
BenchmarkWriteHeader/reused-buffer-mask-u16-16        	277524866	         4.278 ns/op	       0 B/op	       0 allocs/op
BenchmarkWriteHeader/mask-u64
BenchmarkWriteHeader/mask-u64-16                      	72674092	        15.71 ns/op	      16 B/op	       1 allocs/op
BenchmarkWriteHeader/reused-buffer-mask-u64
BenchmarkWriteHeader/reused-buffer-mask-u64-16        	274714274	         4.246 ns/op	       0 B/op	       0 allocs/op
PASS
```
</details>
