### PR TITLE
Cap ReadFrame allocations from peer-declared length

### DIFF
--- a/read.go
+++ b/read.go
@@ -10,7 +10,13 @@ import (
 var (
 	ErrHeaderLengthMSB        = fmt.Errorf("header error: the most significant bit must be 0")
 	ErrHeaderLengthUnexpected = fmt.Errorf("header error: unexpected payload length bits")
+	ErrFrameTooLarge          = fmt.Errorf("frame too large")
 )
+
+// MaxFramePayloadSize is the largest payload ReadFrame will allocate.
+// Zero disables the limit. The default rejects peer-declared lengths that
+// would otherwise OOM the process.
+var MaxFramePayloadSize int64 = 32 << 20
 
 // ReadHeader reads a frame header from r.
 func ReadHeader(r io.Reader) (h Header, err error) {
@@ -111,8 +117,12 @@ func ReadFrame(r io.Reader) (f Frame, err error) {
 	}
 
 	if f.Header.Length > 0 {
-		// int(f.Header.Length) is safe here cause we have
-		// checked it for overflow above in ReadHeader.
+		if MaxFramePayloadSize > 0 && f.Header.Length > MaxFramePayloadSize {
+			return f, ErrFrameTooLarge
+		}
+		if uint64(f.Header.Length) > uint64(^uint(0)>>1) {
+			return f, ErrFrameTooLarge
+		}
 		f.Payload = make([]byte, int(f.Header.Length))
 		_, err = io.ReadFull(r, f.Payload)
 	}

--- a/read_test.go
+++ b/read_test.go
@@ -2,11 +2,23 @@ package ws
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"reflect"
 	"testing"
 )
+
+func TestReadFrameRejectsOversizedPayload(t *testing.T) {
+	hdr := make([]byte, 10)
+	hdr[0] = 0x82
+	hdr[1] = 127
+	binary.BigEndian.PutUint64(hdr[2:], uint64(MaxFramePayloadSize)+1)
+	_, err := ReadFrame(bytes.NewReader(hdr))
+	if err != ErrFrameTooLarge {
+		t.Fatalf("ReadFrame() = %v, want ErrFrameTooLarge", err)
+	}
+}
 
 func TestReadHeader(t *testing.T) {
 	for i, test := range append([]RWTestCase{

--- a/wsutil/helper.go
+++ b/wsutil/helper.go
@@ -26,9 +26,10 @@ type Message struct {
 // TODO(gobwas): add DefaultReader with buffer size options.
 func ReadMessage(r io.Reader, s ws.State, m []Message) ([]Message, error) {
 	rd := Reader{
-		Source:    r,
-		State:     s,
-		CheckUTF8: true,
+		Source:       r,
+		State:        s,
+		CheckUTF8:    true,
+		MaxFrameSize: ws.MaxFramePayloadSize,
 		OnIntermediate: func(hdr ws.Header, src io.Reader) error {
 			bts, err := ioutil.ReadAll(src)
 			if err != nil {


### PR DESCRIPTION
`ReadFrame` allocated `make([]byte, Header.Length)` with no limit, so a post-handshake peer could declare a huge payload and OOM the process.

Honor `MaxFramePayloadSize` (default 32MiB). Set it to 0 to restore the old unlimited behavior. `wsutil.ReadMessage` uses the same cap.

Fixes #223

## Test
`go test . -run TestReadFrameRejectsOversizedPayload -count=1`
